### PR TITLE
feat: updated ABIs with latest release

### DIFF
--- a/app-chain/abis/AppChainGateway.abi.json
+++ b/app-chain/abis/AppChainGateway.abi.json
@@ -1,172 +1,400 @@
 [
-    {
-        "type": "constructor",
-        "inputs": [
-            { "name": "parameterRegistry_", "type": "address", "internalType": "address" },
-            { "name": "settlementChainGateway_", "type": "address", "internalType": "address" }
-        ],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "implementation",
-        "inputs": [],
-        "outputs": [{ "name": "implementation_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    { "type": "function", "name": "initialize", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    { "type": "function", "name": "migrate", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "migratorParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "parameterRegistry",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "parameterRegistry_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "settlementChainGateway_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "implementation",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "implementation_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "migrate",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "migratorParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "parameterRegistry",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "paused",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "paused_",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "pausedParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "receiveDeposit",
+    "inputs": [
+      {
+        "name": "recipient_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "receiveParameters",
+    "inputs": [
+      {
+        "name": "nonce_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "keys_",
+        "type": "string[]",
+        "internalType": "string[]"
+      },
+      {
+        "name": "values_",
+        "type": "bytes32[]",
+        "internalType": "bytes32[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "settlementChainGateway",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "settlementChainGatewayAlias",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "updatePauseStatus",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "withdraw",
+    "inputs": [
+      {
+        "name": "recipient_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "withdrawIntoUnderlying",
+    "inputs": [
+      {
+        "name": "recipient_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "event",
+    "name": "DepositReceived",
+    "inputs": [
+      {
+        "name": "recipient",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Migrated",
+    "inputs": [
+      {
+        "name": "migrator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ParametersReceived",
+    "inputs": [
+      {
+        "name": "nonce",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "keys",
+        "type": "string[]",
+        "indexed": false,
+        "internalType": "string[]"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PauseStatusUpdated",
+    "inputs": [
+      {
         "name": "paused",
-        "inputs": [],
-        "outputs": [{ "name": "paused_", "type": "bool", "internalType": "bool" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "pausedParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "receiveDeposit",
-        "inputs": [{ "name": "recipient_", "type": "address", "internalType": "address" }],
-        "outputs": [],
-        "stateMutability": "payable"
-    },
-    {
-        "type": "function",
-        "name": "receiveParameters",
-        "inputs": [
-            { "name": "nonce_", "type": "uint256", "internalType": "uint256" },
-            { "name": "keys_", "type": "string[]", "internalType": "string[]" },
-            { "name": "values_", "type": "bytes32[]", "internalType": "bytes32[]" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "settlementChainGateway",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "settlementChainGatewayAlias",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    { "type": "function", "name": "updatePauseStatus", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "withdraw",
-        "inputs": [{ "name": "recipient_", "type": "address", "internalType": "address" }],
-        "outputs": [],
-        "stateMutability": "payable"
-    },
-    {
-        "type": "function",
-        "name": "withdrawIntoUnderlying",
-        "inputs": [{ "name": "recipient_", "type": "address", "internalType": "address" }],
-        "outputs": [],
-        "stateMutability": "payable"
-    },
-    {
-        "type": "event",
-        "name": "DepositReceived",
-        "inputs": [
-            { "name": "recipient", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "amount", "type": "uint256", "indexed": false, "internalType": "uint256" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Initialized",
-        "inputs": [{ "name": "version", "type": "uint64", "indexed": false, "internalType": "uint64" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Migrated",
-        "inputs": [{ "name": "migrator", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "ParametersReceived",
-        "inputs": [
-            { "name": "nonce", "type": "uint256", "indexed": true, "internalType": "uint256" },
-            { "name": "keys", "type": "string[]", "indexed": false, "internalType": "string[]" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "PauseStatusUpdated",
-        "inputs": [{ "name": "paused", "type": "bool", "indexed": true, "internalType": "bool" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Upgraded",
-        "inputs": [{ "name": "implementation", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Withdrawal",
-        "inputs": [
-            { "name": "account", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "messageId", "type": "uint256", "indexed": true, "internalType": "uint256" },
-            { "name": "recipient", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "amount", "type": "uint256", "indexed": false, "internalType": "uint256" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "error",
-        "name": "EmptyCode",
-        "inputs": [{ "name": "migrator_", "type": "address", "internalType": "address" }]
-    },
-    { "type": "error", "name": "InvalidInitialization", "inputs": [] },
-    {
-        "type": "error",
-        "name": "MigrationFailed",
-        "inputs": [
-            { "name": "migrator_", "type": "address", "internalType": "address" },
-            { "name": "revertData_", "type": "bytes", "internalType": "bytes" }
-        ]
-    },
-    { "type": "error", "name": "NoChange", "inputs": [] },
-    { "type": "error", "name": "NotInitializing", "inputs": [] },
-    { "type": "error", "name": "NotSettlementChainGateway", "inputs": [] },
-    { "type": "error", "name": "ParameterOutOfTypeBounds", "inputs": [] },
-    { "type": "error", "name": "Paused", "inputs": [] },
-    { "type": "error", "name": "TransferFailed", "inputs": [] },
-    { "type": "error", "name": "ZeroMigrator", "inputs": [] },
-    { "type": "error", "name": "ZeroParameterRegistry", "inputs": [] },
-    { "type": "error", "name": "ZeroRecipient", "inputs": [] },
-    { "type": "error", "name": "ZeroSettlementChainGateway", "inputs": [] },
-    { "type": "error", "name": "ZeroWithdrawalAmount", "inputs": [] }
+        "type": "bool",
+        "indexed": true,
+        "internalType": "bool"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Withdrawal",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "messageId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "recipient",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "EmptyCode",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InvalidInitialization",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MigrationFailed",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "revertData_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "NoChange",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotSettlementChainGateway",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ParameterOutOfTypeBounds",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Paused",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "TransferFailed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroMigrator",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroParameterRegistry",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroRecipient",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroSettlementChainGateway",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroWithdrawalAmount",
+    "inputs": []
+  }
 ]

--- a/app-chain/abis/AppChainParameterRegistry.abi.json
+++ b/app-chain/abis/AppChainParameterRegistry.abi.json
@@ -1,130 +1,305 @@
 [
-    {
-        "type": "function",
-        "name": "adminParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "get",
-        "inputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "outputs": [{ "name": "value_", "type": "bytes32", "internalType": "bytes32" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "get",
-        "inputs": [{ "name": "keys_", "type": "string[]", "internalType": "string[]" }],
-        "outputs": [{ "name": "values_", "type": "bytes32[]", "internalType": "bytes32[]" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
+  {
+    "type": "function",
+    "name": "adminParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "get",
+    "inputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "value_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "get",
+    "inputs": [
+      {
+        "name": "keys_",
+        "type": "string[]",
+        "internalType": "string[]"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "values_",
+        "type": "bytes32[]",
+        "internalType": "bytes32[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "implementation",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "implementation_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [
+      {
+        "name": "admins_",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "isAdmin",
+    "inputs": [
+      {
+        "name": "account_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "isAdmin_",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "migrate",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "migratorParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "set",
+    "inputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "value_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "set",
+    "inputs": [
+      {
+        "name": "keys_",
+        "type": "string[]",
+        "internalType": "string[]"
+      },
+      {
+        "name": "values_",
+        "type": "bytes32[]",
+        "internalType": "bytes32[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Migrated",
+    "inputs": [
+      {
+        "name": "migrator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ParameterSet",
+    "inputs": [
+      {
+        "name": "key",
+        "type": "string",
+        "indexed": true,
+        "internalType": "string"
+      },
+      {
+        "name": "value",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
         "name": "implementation",
-        "inputs": [],
-        "outputs": [{ "name": "implementation_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "initialize",
-        "inputs": [{ "name": "admins_", "type": "address[]", "internalType": "address[]" }],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "isAdmin",
-        "inputs": [{ "name": "account_", "type": "address", "internalType": "address" }],
-        "outputs": [{ "name": "isAdmin_", "type": "bool", "internalType": "bool" }],
-        "stateMutability": "view"
-    },
-    { "type": "function", "name": "migrate", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "migratorParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "set",
-        "inputs": [
-            { "name": "key_", "type": "string", "internalType": "string" },
-            { "name": "value_", "type": "bytes32", "internalType": "bytes32" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "set",
-        "inputs": [
-            { "name": "keys_", "type": "string[]", "internalType": "string[]" },
-            { "name": "values_", "type": "bytes32[]", "internalType": "bytes32[]" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "event",
-        "name": "Initialized",
-        "inputs": [{ "name": "version", "type": "uint64", "indexed": false, "internalType": "uint64" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Migrated",
-        "inputs": [{ "name": "migrator", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "ParameterSet",
-        "inputs": [
-            { "name": "key", "type": "string", "indexed": true, "internalType": "string" },
-            { "name": "value", "type": "bytes32", "indexed": true, "internalType": "bytes32" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Upgraded",
-        "inputs": [{ "name": "implementation", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    { "type": "error", "name": "ArrayLengthMismatch", "inputs": [] },
-    { "type": "error", "name": "EmptyAdmins", "inputs": [] },
-    {
-        "type": "error",
-        "name": "EmptyCode",
-        "inputs": [{ "name": "migrator_", "type": "address", "internalType": "address" }]
-    },
-    { "type": "error", "name": "InvalidInitialization", "inputs": [] },
-    {
-        "type": "error",
-        "name": "MigrationFailed",
-        "inputs": [
-            { "name": "migrator_", "type": "address", "internalType": "address" },
-            { "name": "revertData_", "type": "bytes", "internalType": "bytes" }
-        ]
-    },
-    { "type": "error", "name": "NoKeyComponents", "inputs": [] },
-    { "type": "error", "name": "NoKeys", "inputs": [] },
-    { "type": "error", "name": "NotAdmin", "inputs": [] },
-    { "type": "error", "name": "NotInitializing", "inputs": [] },
-    { "type": "error", "name": "ParameterOutOfTypeBounds", "inputs": [] },
-    {
-        "type": "error",
-        "name": "StringsInsufficientHexLength",
-        "inputs": [
-            { "name": "value", "type": "uint256", "internalType": "uint256" },
-            { "name": "length", "type": "uint256", "internalType": "uint256" }
-        ]
-    },
-    { "type": "error", "name": "ZeroAdmin", "inputs": [] },
-    { "type": "error", "name": "ZeroMigrator", "inputs": [] }
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "ArrayLengthMismatch",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "EmptyAdmins",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "EmptyCode",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InvalidInitialization",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MigrationFailed",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "revertData_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "NoKeyComponents",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NoKeys",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotAdmin",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ParameterOutOfTypeBounds",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "StringsInsufficientHexLength",
+    "inputs": [
+      {
+        "name": "value",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "length",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ZeroAdmin",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroMigrator",
+    "inputs": []
+  }
 ]

--- a/app-chain/abis/Factory.abi.json
+++ b/app-chain/abis/Factory.abi.json
@@ -1,153 +1,376 @@
 [
-    {
-        "type": "constructor",
-        "inputs": [{ "name": "parameterRegistry_", "type": "address", "internalType": "address" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "computeImplementationAddress",
-        "inputs": [{ "name": "bytecode_", "type": "bytes", "internalType": "bytes" }],
-        "outputs": [{ "name": "implementation_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "computeProxyAddress",
-        "inputs": [
-            { "name": "caller_", "type": "address", "internalType": "address" },
-            { "name": "salt_", "type": "bytes32", "internalType": "bytes32" }
-        ],
-        "outputs": [{ "name": "proxy_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "deployImplementation",
-        "inputs": [{ "name": "bytecode_", "type": "bytes", "internalType": "bytes" }],
-        "outputs": [{ "name": "implementation_", "type": "address", "internalType": "address" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "deployProxy",
-        "inputs": [
-            { "name": "implementation_", "type": "address", "internalType": "address" },
-            { "name": "salt_", "type": "bytes32", "internalType": "bytes32" },
-            { "name": "initializeCallData_", "type": "bytes", "internalType": "bytes" }
-        ],
-        "outputs": [{ "name": "proxy_", "type": "address", "internalType": "address" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "parameterRegistry_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "computeImplementationAddress",
+    "inputs": [
+      {
+        "name": "bytecode_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "implementation_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "computeProxyAddress",
+    "inputs": [
+      {
+        "name": "caller_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "salt_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "proxy_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "deployImplementation",
+    "inputs": [
+      {
+        "name": "bytecode_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "implementation_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "deployProxy",
+    "inputs": [
+      {
+        "name": "implementation_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "salt_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "initializeCallData_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "proxy_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "implementation",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "implementation_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initializableImplementation",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "initializableImplementation_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "migrate",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "migratorParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "parameterRegistry",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "paused",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "paused_",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "pausedParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "event",
+    "name": "ImplementationDeployed",
+    "inputs": [
+      {
         "name": "implementation",
-        "inputs": [],
-        "outputs": [{ "name": "implementation_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "initializableImplementation",
-        "inputs": [],
-        "outputs": [{ "name": "initializableImplementation_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    { "type": "function", "name": "initialize", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    { "type": "function", "name": "migrate", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "migratorParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "parameterRegistry",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "paused",
-        "inputs": [],
-        "outputs": [{ "name": "paused_", "type": "bool", "internalType": "bool" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "pausedParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "event",
-        "name": "ImplementationDeployed",
-        "inputs": [
-            { "name": "implementation", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "bytecodeHash", "type": "bytes32", "indexed": true, "internalType": "bytes32" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "InitializableImplementationDeployed",
-        "inputs": [{ "name": "implementation", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Initialized",
-        "inputs": [{ "name": "version", "type": "uint64", "indexed": false, "internalType": "uint64" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Migrated",
-        "inputs": [{ "name": "migrator", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "ProxyDeployed",
-        "inputs": [
-            { "name": "proxy", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "implementation", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "sender", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "salt", "type": "bytes32", "indexed": false, "internalType": "bytes32" },
-            { "name": "initializeCallData", "type": "bytes", "indexed": false, "internalType": "bytes" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Upgraded",
-        "inputs": [{ "name": "implementation", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    { "type": "error", "name": "DeployFailed", "inputs": [] },
-    { "type": "error", "name": "EmptyBytecode", "inputs": [] },
-    {
-        "type": "error",
-        "name": "EmptyCode",
-        "inputs": [{ "name": "migrator_", "type": "address", "internalType": "address" }]
-    },
-    { "type": "error", "name": "InvalidImplementation", "inputs": [] },
-    { "type": "error", "name": "InvalidInitialization", "inputs": [] },
-    {
-        "type": "error",
-        "name": "MigrationFailed",
-        "inputs": [
-            { "name": "migrator_", "type": "address", "internalType": "address" },
-            { "name": "revertData_", "type": "bytes", "internalType": "bytes" }
-        ]
-    },
-    { "type": "error", "name": "NotInitializing", "inputs": [] },
-    { "type": "error", "name": "ParameterOutOfTypeBounds", "inputs": [] },
-    { "type": "error", "name": "Paused", "inputs": [] },
-    { "type": "error", "name": "ZeroMigrator", "inputs": [] },
-    { "type": "error", "name": "ZeroParameterRegistry", "inputs": [] }
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "bytecodeHash",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "InitializableImplementationDeployed",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Migrated",
+    "inputs": [
+      {
+        "name": "migrator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ProxyDeployed",
+    "inputs": [
+      {
+        "name": "proxy",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "sender",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "salt",
+        "type": "bytes32",
+        "indexed": false,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "initializeCallData",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "DeployFailed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "EmptyBytecode",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "EmptyCode",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InvalidImplementation",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidInitialization",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MigrationFailed",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "revertData_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ParameterOutOfTypeBounds",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Paused",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroMigrator",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroParameterRegistry",
+    "inputs": []
+  }
 ]

--- a/app-chain/abis/GroupMessageBroadcaster.abi.json
+++ b/app-chain/abis/GroupMessageBroadcaster.abi.json
@@ -1,216 +1,468 @@
 [
-    {
-        "type": "constructor",
-        "inputs": [{ "name": "parameterRegistry_", "type": "address", "internalType": "address" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "addMessage",
-        "inputs": [
-            { "name": "groupId_", "type": "bytes16", "internalType": "bytes16" },
-            { "name": "message_", "type": "bytes", "internalType": "bytes" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "bootstrapMessages",
-        "inputs": [
-            { "name": "groupIds_", "type": "bytes16[]", "internalType": "bytes16[]" },
-            { "name": "messages_", "type": "bytes[]", "internalType": "bytes[]" },
-            { "name": "sequenceIds_", "type": "uint64[]", "internalType": "uint64[]" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "implementation",
-        "inputs": [],
-        "outputs": [{ "name": "implementation_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    { "type": "function", "name": "initialize", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "maxPayloadSize",
-        "inputs": [],
-        "outputs": [{ "name": "size_", "type": "uint32", "internalType": "uint32" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "maxPayloadSizeParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    { "type": "function", "name": "migrate", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "migratorParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "minPayloadSize",
-        "inputs": [],
-        "outputs": [{ "name": "size_", "type": "uint32", "internalType": "uint32" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "minPayloadSizeParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "parameterRegistry",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "parameterRegistry_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "addMessage",
+    "inputs": [
+      {
+        "name": "groupId_",
+        "type": "bytes16",
+        "internalType": "bytes16"
+      },
+      {
+        "name": "message_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "bootstrapMessages",
+    "inputs": [
+      {
+        "name": "groupIds_",
+        "type": "bytes16[]",
+        "internalType": "bytes16[]"
+      },
+      {
+        "name": "messages_",
+        "type": "bytes[]",
+        "internalType": "bytes[]"
+      },
+      {
+        "name": "sequenceIds_",
+        "type": "uint64[]",
+        "internalType": "uint64[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "implementation",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "implementation_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "maxPayloadSize",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "size_",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "maxPayloadSizeParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "migrate",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "migratorParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "minPayloadSize",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "size_",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "minPayloadSizeParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "parameterRegistry",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "paused",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "paused_",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "pausedParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "payloadBootstrapper",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "payloadBootstrapper_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "payloadBootstrapperParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "updateMaxPayloadSize",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateMinPayloadSize",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updatePauseStatus",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updatePayloadBootstrapper",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "MaxPayloadSizeUpdated",
+    "inputs": [
+      {
+        "name": "size",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "MessageSent",
+    "inputs": [
+      {
+        "name": "groupId",
+        "type": "bytes16",
+        "indexed": true,
+        "internalType": "bytes16"
+      },
+      {
+        "name": "message",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      },
+      {
+        "name": "sequenceId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Migrated",
+    "inputs": [
+      {
+        "name": "migrator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "MinPayloadSizeUpdated",
+    "inputs": [
+      {
+        "name": "size",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PauseStatusUpdated",
+    "inputs": [
+      {
         "name": "paused",
-        "inputs": [],
-        "outputs": [{ "name": "paused_", "type": "bool", "internalType": "bool" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "pausedParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
+        "type": "bool",
+        "indexed": true,
+        "internalType": "bool"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PayloadBootstrapperUpdated",
+    "inputs": [
+      {
         "name": "payloadBootstrapper",
-        "inputs": [],
-        "outputs": [{ "name": "payloadBootstrapper_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "payloadBootstrapperParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "updateMaxPayloadSize",
-        "inputs": [],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "updateMinPayloadSize",
-        "inputs": [],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    { "type": "function", "name": "updatePauseStatus", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "updatePayloadBootstrapper",
-        "inputs": [],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "event",
-        "name": "Initialized",
-        "inputs": [{ "name": "version", "type": "uint64", "indexed": false, "internalType": "uint64" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "MaxPayloadSizeUpdated",
-        "inputs": [{ "name": "size", "type": "uint256", "indexed": true, "internalType": "uint256" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "MessageSent",
-        "inputs": [
-            { "name": "groupId", "type": "bytes16", "indexed": true, "internalType": "bytes16" },
-            { "name": "message", "type": "bytes", "indexed": false, "internalType": "bytes" },
-            { "name": "sequenceId", "type": "uint64", "indexed": true, "internalType": "uint64" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Migrated",
-        "inputs": [{ "name": "migrator", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "MinPayloadSizeUpdated",
-        "inputs": [{ "name": "size", "type": "uint256", "indexed": true, "internalType": "uint256" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "PauseStatusUpdated",
-        "inputs": [{ "name": "paused", "type": "bool", "indexed": true, "internalType": "bool" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "PayloadBootstrapperUpdated",
-        "inputs": [{ "name": "payloadBootstrapper", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Upgraded",
-        "inputs": [{ "name": "implementation", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    { "type": "error", "name": "ArrayLengthMismatch", "inputs": [] },
-    { "type": "error", "name": "EmptyArray", "inputs": [] },
-    {
-        "type": "error",
-        "name": "EmptyCode",
-        "inputs": [{ "name": "migrator_", "type": "address", "internalType": "address" }]
-    },
-    { "type": "error", "name": "InvalidInitialization", "inputs": [] },
-    { "type": "error", "name": "InvalidMaxPayloadSize", "inputs": [] },
-    { "type": "error", "name": "InvalidMinPayloadSize", "inputs": [] },
-    {
-        "type": "error",
-        "name": "InvalidPayloadSize",
-        "inputs": [
-            { "name": "actualSize_", "type": "uint256", "internalType": "uint256" },
-            { "name": "minSize_", "type": "uint256", "internalType": "uint256" },
-            { "name": "maxSize_", "type": "uint256", "internalType": "uint256" }
-        ]
-    },
-    {
-        "type": "error",
-        "name": "MigrationFailed",
-        "inputs": [
-            { "name": "migrator_", "type": "address", "internalType": "address" },
-            { "name": "revertData_", "type": "bytes", "internalType": "bytes" }
-        ]
-    },
-    { "type": "error", "name": "NoChange", "inputs": [] },
-    { "type": "error", "name": "NotInitializing", "inputs": [] },
-    { "type": "error", "name": "NotPaused", "inputs": [] },
-    { "type": "error", "name": "NotPayloadBootstrapper", "inputs": [] },
-    { "type": "error", "name": "ParameterOutOfTypeBounds", "inputs": [] },
-    { "type": "error", "name": "Paused", "inputs": [] },
-    { "type": "error", "name": "ZeroMigrator", "inputs": [] },
-    { "type": "error", "name": "ZeroParameterRegistry", "inputs": [] }
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "ArrayLengthMismatch",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "EmptyArray",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "EmptyCode",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InvalidInitialization",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidMaxPayloadSize",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidMinPayloadSize",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidPayloadSize",
+    "inputs": [
+      {
+        "name": "actualSize_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "minSize_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "maxSize_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "MigrationFailed",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "revertData_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "NoChange",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotPaused",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotPayloadBootstrapper",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ParameterOutOfTypeBounds",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Paused",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroMigrator",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroParameterRegistry",
+    "inputs": []
+  }
 ]

--- a/app-chain/abis/IdentityUpdateBroadcaster.abi.json
+++ b/app-chain/abis/IdentityUpdateBroadcaster.abi.json
@@ -1,216 +1,468 @@
 [
-    {
-        "type": "constructor",
-        "inputs": [{ "name": "parameterRegistry_", "type": "address", "internalType": "address" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "addIdentityUpdate",
-        "inputs": [
-            { "name": "inboxId_", "type": "bytes32", "internalType": "bytes32" },
-            { "name": "identityUpdate_", "type": "bytes", "internalType": "bytes" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "bootstrapIdentityUpdates",
-        "inputs": [
-            { "name": "inboxIds_", "type": "bytes32[]", "internalType": "bytes32[]" },
-            { "name": "identityUpdates_", "type": "bytes[]", "internalType": "bytes[]" },
-            { "name": "sequenceIds_", "type": "uint64[]", "internalType": "uint64[]" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "implementation",
-        "inputs": [],
-        "outputs": [{ "name": "implementation_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    { "type": "function", "name": "initialize", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "maxPayloadSize",
-        "inputs": [],
-        "outputs": [{ "name": "size_", "type": "uint32", "internalType": "uint32" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "maxPayloadSizeParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    { "type": "function", "name": "migrate", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "migratorParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "minPayloadSize",
-        "inputs": [],
-        "outputs": [{ "name": "size_", "type": "uint32", "internalType": "uint32" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "minPayloadSizeParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "parameterRegistry",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "parameterRegistry_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "addIdentityUpdate",
+    "inputs": [
+      {
+        "name": "inboxId_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "identityUpdate_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "bootstrapIdentityUpdates",
+    "inputs": [
+      {
+        "name": "inboxIds_",
+        "type": "bytes32[]",
+        "internalType": "bytes32[]"
+      },
+      {
+        "name": "identityUpdates_",
+        "type": "bytes[]",
+        "internalType": "bytes[]"
+      },
+      {
+        "name": "sequenceIds_",
+        "type": "uint64[]",
+        "internalType": "uint64[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "implementation",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "implementation_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "maxPayloadSize",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "size_",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "maxPayloadSizeParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "migrate",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "migratorParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "minPayloadSize",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "size_",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "minPayloadSizeParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "parameterRegistry",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "paused",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "paused_",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "pausedParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "payloadBootstrapper",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "payloadBootstrapper_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "payloadBootstrapperParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "updateMaxPayloadSize",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateMinPayloadSize",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updatePauseStatus",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updatePayloadBootstrapper",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "IdentityUpdateCreated",
+    "inputs": [
+      {
+        "name": "inboxId",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "update",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      },
+      {
+        "name": "sequenceId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "MaxPayloadSizeUpdated",
+    "inputs": [
+      {
+        "name": "size",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Migrated",
+    "inputs": [
+      {
+        "name": "migrator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "MinPayloadSizeUpdated",
+    "inputs": [
+      {
+        "name": "size",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PauseStatusUpdated",
+    "inputs": [
+      {
         "name": "paused",
-        "inputs": [],
-        "outputs": [{ "name": "paused_", "type": "bool", "internalType": "bool" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "pausedParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
+        "type": "bool",
+        "indexed": true,
+        "internalType": "bool"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PayloadBootstrapperUpdated",
+    "inputs": [
+      {
         "name": "payloadBootstrapper",
-        "inputs": [],
-        "outputs": [{ "name": "payloadBootstrapper_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "payloadBootstrapperParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "updateMaxPayloadSize",
-        "inputs": [],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "updateMinPayloadSize",
-        "inputs": [],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    { "type": "function", "name": "updatePauseStatus", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "updatePayloadBootstrapper",
-        "inputs": [],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "event",
-        "name": "IdentityUpdateCreated",
-        "inputs": [
-            { "name": "inboxId", "type": "bytes32", "indexed": true, "internalType": "bytes32" },
-            { "name": "update", "type": "bytes", "indexed": false, "internalType": "bytes" },
-            { "name": "sequenceId", "type": "uint64", "indexed": true, "internalType": "uint64" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Initialized",
-        "inputs": [{ "name": "version", "type": "uint64", "indexed": false, "internalType": "uint64" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "MaxPayloadSizeUpdated",
-        "inputs": [{ "name": "size", "type": "uint256", "indexed": true, "internalType": "uint256" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Migrated",
-        "inputs": [{ "name": "migrator", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "MinPayloadSizeUpdated",
-        "inputs": [{ "name": "size", "type": "uint256", "indexed": true, "internalType": "uint256" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "PauseStatusUpdated",
-        "inputs": [{ "name": "paused", "type": "bool", "indexed": true, "internalType": "bool" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "PayloadBootstrapperUpdated",
-        "inputs": [{ "name": "payloadBootstrapper", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Upgraded",
-        "inputs": [{ "name": "implementation", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    { "type": "error", "name": "ArrayLengthMismatch", "inputs": [] },
-    { "type": "error", "name": "EmptyArray", "inputs": [] },
-    {
-        "type": "error",
-        "name": "EmptyCode",
-        "inputs": [{ "name": "migrator_", "type": "address", "internalType": "address" }]
-    },
-    { "type": "error", "name": "InvalidInitialization", "inputs": [] },
-    { "type": "error", "name": "InvalidMaxPayloadSize", "inputs": [] },
-    { "type": "error", "name": "InvalidMinPayloadSize", "inputs": [] },
-    {
-        "type": "error",
-        "name": "InvalidPayloadSize",
-        "inputs": [
-            { "name": "actualSize_", "type": "uint256", "internalType": "uint256" },
-            { "name": "minSize_", "type": "uint256", "internalType": "uint256" },
-            { "name": "maxSize_", "type": "uint256", "internalType": "uint256" }
-        ]
-    },
-    {
-        "type": "error",
-        "name": "MigrationFailed",
-        "inputs": [
-            { "name": "migrator_", "type": "address", "internalType": "address" },
-            { "name": "revertData_", "type": "bytes", "internalType": "bytes" }
-        ]
-    },
-    { "type": "error", "name": "NoChange", "inputs": [] },
-    { "type": "error", "name": "NotInitializing", "inputs": [] },
-    { "type": "error", "name": "NotPaused", "inputs": [] },
-    { "type": "error", "name": "NotPayloadBootstrapper", "inputs": [] },
-    { "type": "error", "name": "ParameterOutOfTypeBounds", "inputs": [] },
-    { "type": "error", "name": "Paused", "inputs": [] },
-    { "type": "error", "name": "ZeroMigrator", "inputs": [] },
-    { "type": "error", "name": "ZeroParameterRegistry", "inputs": [] }
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "ArrayLengthMismatch",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "EmptyArray",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "EmptyCode",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InvalidInitialization",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidMaxPayloadSize",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidMinPayloadSize",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidPayloadSize",
+    "inputs": [
+      {
+        "name": "actualSize_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "minSize_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "maxSize_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "MigrationFailed",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "revertData_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "NoChange",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotPaused",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotPayloadBootstrapper",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ParameterOutOfTypeBounds",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Paused",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroMigrator",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroParameterRegistry",
+    "inputs": []
+  }
 ]

--- a/settlement-chain/abis/DistributionManager.abi.json
+++ b/settlement-chain/abis/DistributionManager.abi.json
@@ -1,316 +1,737 @@
 [
-    {
-        "type": "constructor",
-        "inputs": [
-            { "name": "parameterRegistry_", "type": "address", "internalType": "address" },
-            { "name": "nodeRegistry_", "type": "address", "internalType": "address" },
-            { "name": "payerReportManager_", "type": "address", "internalType": "address" },
-            { "name": "payerRegistry_", "type": "address", "internalType": "address" },
-            { "name": "feeToken_", "type": "address", "internalType": "address" }
-        ],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "areFeesClaimed",
-        "inputs": [
-            { "name": "nodeId_", "type": "uint32", "internalType": "uint32" },
-            { "name": "originatorNodeId_", "type": "uint32", "internalType": "uint32" },
-            { "name": "payerReportIndex_", "type": "uint256", "internalType": "uint256" }
-        ],
-        "outputs": [{ "name": "hasClaimed_", "type": "bool", "internalType": "bool" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "areProtocolFeesClaimed",
-        "inputs": [
-            { "name": "originatorNodeId_", "type": "uint32", "internalType": "uint32" },
-            { "name": "payerReportIndex_", "type": "uint256", "internalType": "uint256" }
-        ],
-        "outputs": [{ "name": "areClaimed_", "type": "bool", "internalType": "bool" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "claim",
-        "inputs": [
-            { "name": "nodeId_", "type": "uint32", "internalType": "uint32" },
-            { "name": "originatorNodeIds_", "type": "uint32[]", "internalType": "uint32[]" },
-            { "name": "payerReportIndices_", "type": "uint256[]", "internalType": "uint256[]" }
-        ],
-        "outputs": [{ "name": "claimed_", "type": "uint96", "internalType": "uint96" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "claimProtocolFees",
-        "inputs": [
-            { "name": "originatorNodeIds_", "type": "uint32[]", "internalType": "uint32[]" },
-            { "name": "payerReportIndices_", "type": "uint256[]", "internalType": "uint256[]" }
-        ],
-        "outputs": [{ "name": "claimed_", "type": "uint96", "internalType": "uint96" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "feeToken",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "getOwedFees",
-        "inputs": [{ "name": "nodeId_", "type": "uint32", "internalType": "uint32" }],
-        "outputs": [{ "name": "owedFees_", "type": "uint96", "internalType": "uint96" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "implementation",
-        "inputs": [],
-        "outputs": [{ "name": "implementation_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    { "type": "function", "name": "initialize", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    { "type": "function", "name": "migrate", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "migratorParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "nodeRegistry",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "owedProtocolFees",
-        "inputs": [],
-        "outputs": [{ "name": "owedProtocolFees_", "type": "uint96", "internalType": "uint96" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "parameterRegistry",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "parameterRegistry_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "nodeRegistry_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "payerReportManager_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "payerRegistry_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "feeToken_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "areFeesClaimed",
+    "inputs": [
+      {
+        "name": "nodeId_",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "originatorNodeId_",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "payerReportIndex_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "hasClaimed_",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "areProtocolFeesClaimed",
+    "inputs": [
+      {
+        "name": "originatorNodeId_",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "payerReportIndex_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "areClaimed_",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "claim",
+    "inputs": [
+      {
+        "name": "nodeId_",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "originatorNodeIds_",
+        "type": "uint32[]",
+        "internalType": "uint32[]"
+      },
+      {
+        "name": "payerReportIndices_",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "claimed_",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "claimProtocolFees",
+    "inputs": [
+      {
+        "name": "originatorNodeIds_",
+        "type": "uint32[]",
+        "internalType": "uint32[]"
+      },
+      {
+        "name": "payerReportIndices_",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "claimed_",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "feeToken",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getOwedFees",
+    "inputs": [
+      {
+        "name": "nodeId_",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "owedFees_",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "implementation",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "implementation_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "migrate",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "migratorParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "nodeRegistry",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "owedProtocolFees",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "owedProtocolFees_",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "parameterRegistry",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "paused",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "paused_",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "pausedParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "payerRegistry",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "payerReportManager",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "protocolFeesRecipient",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "protocolFeesRecipient_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "protocolFeesRecipientParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "totalOwedFees",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "totalOwedFees_",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "updatePauseStatus",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateProtocolFeesRecipient",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "withdraw",
+    "inputs": [
+      {
+        "name": "nodeId_",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "recipient_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "withdrawn_",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "withdrawIntoUnderlying",
+    "inputs": [
+      {
+        "name": "nodeId_",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "recipient_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "withdrawn_",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "withdrawProtocolFees",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "withdrawn_",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "withdrawProtocolFeesIntoUnderlying",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "withdrawn_",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "Claim",
+    "inputs": [
+      {
+        "name": "nodeId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "originatorNodeId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "payerReportIndex",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "amount",
+        "type": "uint96",
+        "indexed": false,
+        "internalType": "uint96"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Migrated",
+    "inputs": [
+      {
+        "name": "migrator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PauseStatusUpdated",
+    "inputs": [
+      {
         "name": "paused",
-        "inputs": [],
-        "outputs": [{ "name": "paused_", "type": "bool", "internalType": "bool" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "pausedParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "payerRegistry",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "payerReportManager",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
+        "type": "bool",
+        "indexed": true,
+        "internalType": "bool"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ProtocolFeesClaim",
+    "inputs": [
+      {
+        "name": "originatorNodeId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "payerReportIndex",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "amount",
+        "type": "uint96",
+        "indexed": false,
+        "internalType": "uint96"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ProtocolFeesRecipientUpdated",
+    "inputs": [
+      {
         "name": "protocolFeesRecipient",
-        "inputs": [],
-        "outputs": [{ "name": "protocolFeesRecipient_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "protocolFeesRecipientParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "totalOwedFees",
-        "inputs": [],
-        "outputs": [{ "name": "totalOwedFees_", "type": "uint96", "internalType": "uint96" }],
-        "stateMutability": "view"
-    },
-    { "type": "function", "name": "updatePauseStatus", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "updateProtocolFeesRecipient",
-        "inputs": [],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "withdraw",
-        "inputs": [
-            { "name": "nodeId_", "type": "uint32", "internalType": "uint32" },
-            { "name": "recipient_", "type": "address", "internalType": "address" }
-        ],
-        "outputs": [{ "name": "withdrawn_", "type": "uint96", "internalType": "uint96" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "withdrawIntoUnderlying",
-        "inputs": [
-            { "name": "nodeId_", "type": "uint32", "internalType": "uint32" },
-            { "name": "recipient_", "type": "address", "internalType": "address" }
-        ],
-        "outputs": [{ "name": "withdrawn_", "type": "uint96", "internalType": "uint96" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "withdrawProtocolFees",
-        "inputs": [],
-        "outputs": [{ "name": "withdrawn_", "type": "uint96", "internalType": "uint96" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "withdrawProtocolFeesIntoUnderlying",
-        "inputs": [],
-        "outputs": [{ "name": "withdrawn_", "type": "uint96", "internalType": "uint96" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "event",
-        "name": "Claim",
-        "inputs": [
-            { "name": "nodeId", "type": "uint32", "indexed": true, "internalType": "uint32" },
-            { "name": "originatorNodeId", "type": "uint32", "indexed": true, "internalType": "uint32" },
-            { "name": "payerReportIndex", "type": "uint256", "indexed": true, "internalType": "uint256" },
-            { "name": "amount", "type": "uint96", "indexed": false, "internalType": "uint96" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Initialized",
-        "inputs": [{ "name": "version", "type": "uint64", "indexed": false, "internalType": "uint64" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Migrated",
-        "inputs": [{ "name": "migrator", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "PauseStatusUpdated",
-        "inputs": [{ "name": "paused", "type": "bool", "indexed": true, "internalType": "bool" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "ProtocolFeesClaim",
-        "inputs": [
-            { "name": "originatorNodeId", "type": "uint32", "indexed": true, "internalType": "uint32" },
-            { "name": "payerReportIndex", "type": "uint256", "indexed": true, "internalType": "uint256" },
-            { "name": "amount", "type": "uint96", "indexed": false, "internalType": "uint96" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "ProtocolFeesRecipientUpdated",
-        "inputs": [{ "name": "protocolFeesRecipient", "type": "address", "indexed": false, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "ProtocolFeesWithdrawal",
-        "inputs": [{ "name": "amount", "type": "uint96", "indexed": false, "internalType": "uint96" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Upgraded",
-        "inputs": [{ "name": "implementation", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Withdrawal",
-        "inputs": [
-            { "name": "nodeId", "type": "uint32", "indexed": true, "internalType": "uint32" },
-            { "name": "amount", "type": "uint96", "indexed": false, "internalType": "uint96" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "error",
-        "name": "AlreadyClaimed",
-        "inputs": [
-            { "name": "originatorNodeId", "type": "uint32", "internalType": "uint32" },
-            { "name": "payerReportIndex", "type": "uint256", "internalType": "uint256" }
-        ]
-    },
-    { "type": "error", "name": "ArrayLengthMismatch", "inputs": [] },
-    {
-        "type": "error",
-        "name": "EmptyCode",
-        "inputs": [{ "name": "migrator_", "type": "address", "internalType": "address" }]
-    },
-    { "type": "error", "name": "InvalidInitialization", "inputs": [] },
-    {
-        "type": "error",
-        "name": "MigrationFailed",
-        "inputs": [
-            { "name": "migrator_", "type": "address", "internalType": "address" },
-            { "name": "revertData_", "type": "bytes", "internalType": "bytes" }
-        ]
-    },
-    { "type": "error", "name": "NoChange", "inputs": [] },
-    { "type": "error", "name": "NoFeesOwed", "inputs": [] },
-    {
-        "type": "error",
-        "name": "NotInPayerReport",
-        "inputs": [
-            { "name": "originatorNodeId", "type": "uint32", "internalType": "uint32" },
-            { "name": "payerReportIndex", "type": "uint256", "internalType": "uint256" }
-        ]
-    },
-    { "type": "error", "name": "NotInitializing", "inputs": [] },
-    { "type": "error", "name": "NotNodeOwner", "inputs": [] },
-    { "type": "error", "name": "ParameterOutOfTypeBounds", "inputs": [] },
-    { "type": "error", "name": "Paused", "inputs": [] },
-    {
-        "type": "error",
-        "name": "PayerReportNotSettled",
-        "inputs": [
-            { "name": "originatorNodeId", "type": "uint32", "internalType": "uint32" },
-            { "name": "payerReportIndex", "type": "uint256", "internalType": "uint256" }
-        ]
-    },
-    { "type": "error", "name": "ZeroAvailableBalance", "inputs": [] },
-    { "type": "error", "name": "ZeroFeeToken", "inputs": [] },
-    { "type": "error", "name": "ZeroMigrator", "inputs": [] },
-    { "type": "error", "name": "ZeroNodeRegistry", "inputs": [] },
-    { "type": "error", "name": "ZeroParameterRegistry", "inputs": [] },
-    { "type": "error", "name": "ZeroPayerRegistry", "inputs": [] },
-    { "type": "error", "name": "ZeroPayerReportManager", "inputs": [] },
-    { "type": "error", "name": "ZeroRecipient", "inputs": [] }
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ProtocolFeesWithdrawal",
+    "inputs": [
+      {
+        "name": "amount",
+        "type": "uint96",
+        "indexed": false,
+        "internalType": "uint96"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Withdrawal",
+    "inputs": [
+      {
+        "name": "nodeId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "amount",
+        "type": "uint96",
+        "indexed": false,
+        "internalType": "uint96"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "AlreadyClaimed",
+    "inputs": [
+      {
+        "name": "originatorNodeId",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "payerReportIndex",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ArrayLengthMismatch",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "EmptyCode",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InvalidInitialization",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MigrationFailed",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "revertData_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "NoChange",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NoFeesOwed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotInPayerReport",
+    "inputs": [
+      {
+        "name": "originatorNodeId",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "payerReportIndex",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotNodeOwner",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ParameterOutOfTypeBounds",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Paused",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "PayerReportNotSettled",
+    "inputs": [
+      {
+        "name": "originatorNodeId",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "payerReportIndex",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ZeroAvailableBalance",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroFeeToken",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroMigrator",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroNodeRegistry",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroParameterRegistry",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroPayerRegistry",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroPayerReportManager",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroRecipient",
+    "inputs": []
+  }
 ]

--- a/settlement-chain/abis/Factory.abi.json
+++ b/settlement-chain/abis/Factory.abi.json
@@ -1,153 +1,376 @@
 [
-    {
-        "type": "constructor",
-        "inputs": [{ "name": "parameterRegistry_", "type": "address", "internalType": "address" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "computeImplementationAddress",
-        "inputs": [{ "name": "bytecode_", "type": "bytes", "internalType": "bytes" }],
-        "outputs": [{ "name": "implementation_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "computeProxyAddress",
-        "inputs": [
-            { "name": "caller_", "type": "address", "internalType": "address" },
-            { "name": "salt_", "type": "bytes32", "internalType": "bytes32" }
-        ],
-        "outputs": [{ "name": "proxy_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "deployImplementation",
-        "inputs": [{ "name": "bytecode_", "type": "bytes", "internalType": "bytes" }],
-        "outputs": [{ "name": "implementation_", "type": "address", "internalType": "address" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "deployProxy",
-        "inputs": [
-            { "name": "implementation_", "type": "address", "internalType": "address" },
-            { "name": "salt_", "type": "bytes32", "internalType": "bytes32" },
-            { "name": "initializeCallData_", "type": "bytes", "internalType": "bytes" }
-        ],
-        "outputs": [{ "name": "proxy_", "type": "address", "internalType": "address" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "parameterRegistry_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "computeImplementationAddress",
+    "inputs": [
+      {
+        "name": "bytecode_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "implementation_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "computeProxyAddress",
+    "inputs": [
+      {
+        "name": "caller_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "salt_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "proxy_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "deployImplementation",
+    "inputs": [
+      {
+        "name": "bytecode_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "implementation_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "deployProxy",
+    "inputs": [
+      {
+        "name": "implementation_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "salt_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "initializeCallData_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "proxy_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "implementation",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "implementation_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initializableImplementation",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "initializableImplementation_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "migrate",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "migratorParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "parameterRegistry",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "paused",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "paused_",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "pausedParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "event",
+    "name": "ImplementationDeployed",
+    "inputs": [
+      {
         "name": "implementation",
-        "inputs": [],
-        "outputs": [{ "name": "implementation_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "initializableImplementation",
-        "inputs": [],
-        "outputs": [{ "name": "initializableImplementation_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    { "type": "function", "name": "initialize", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    { "type": "function", "name": "migrate", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "migratorParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "parameterRegistry",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "paused",
-        "inputs": [],
-        "outputs": [{ "name": "paused_", "type": "bool", "internalType": "bool" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "pausedParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "event",
-        "name": "ImplementationDeployed",
-        "inputs": [
-            { "name": "implementation", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "bytecodeHash", "type": "bytes32", "indexed": true, "internalType": "bytes32" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "InitializableImplementationDeployed",
-        "inputs": [{ "name": "implementation", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Initialized",
-        "inputs": [{ "name": "version", "type": "uint64", "indexed": false, "internalType": "uint64" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Migrated",
-        "inputs": [{ "name": "migrator", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "ProxyDeployed",
-        "inputs": [
-            { "name": "proxy", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "implementation", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "sender", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "salt", "type": "bytes32", "indexed": false, "internalType": "bytes32" },
-            { "name": "initializeCallData", "type": "bytes", "indexed": false, "internalType": "bytes" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Upgraded",
-        "inputs": [{ "name": "implementation", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    { "type": "error", "name": "DeployFailed", "inputs": [] },
-    { "type": "error", "name": "EmptyBytecode", "inputs": [] },
-    {
-        "type": "error",
-        "name": "EmptyCode",
-        "inputs": [{ "name": "migrator_", "type": "address", "internalType": "address" }]
-    },
-    { "type": "error", "name": "InvalidImplementation", "inputs": [] },
-    { "type": "error", "name": "InvalidInitialization", "inputs": [] },
-    {
-        "type": "error",
-        "name": "MigrationFailed",
-        "inputs": [
-            { "name": "migrator_", "type": "address", "internalType": "address" },
-            { "name": "revertData_", "type": "bytes", "internalType": "bytes" }
-        ]
-    },
-    { "type": "error", "name": "NotInitializing", "inputs": [] },
-    { "type": "error", "name": "ParameterOutOfTypeBounds", "inputs": [] },
-    { "type": "error", "name": "Paused", "inputs": [] },
-    { "type": "error", "name": "ZeroMigrator", "inputs": [] },
-    { "type": "error", "name": "ZeroParameterRegistry", "inputs": [] }
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "bytecodeHash",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "InitializableImplementationDeployed",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Migrated",
+    "inputs": [
+      {
+        "name": "migrator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ProxyDeployed",
+    "inputs": [
+      {
+        "name": "proxy",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "sender",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "salt",
+        "type": "bytes32",
+        "indexed": false,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "initializeCallData",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "DeployFailed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "EmptyBytecode",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "EmptyCode",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InvalidImplementation",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidInitialization",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MigrationFailed",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "revertData_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ParameterOutOfTypeBounds",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Paused",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroMigrator",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroParameterRegistry",
+    "inputs": []
+  }
 ]

--- a/settlement-chain/abis/FeeToken.abi.json
+++ b/settlement-chain/abis/FeeToken.abi.json
@@ -1,373 +1,905 @@
 [
-    {
-        "type": "constructor",
-        "inputs": [
-            { "name": "parameterRegistry_", "type": "address", "internalType": "address" },
-            { "name": "underlying_", "type": "address", "internalType": "address" }
-        ],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "DOMAIN_SEPARATOR",
-        "inputs": [],
-        "outputs": [{ "name": "domainSeparator_", "type": "bytes32", "internalType": "bytes32" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "PERMIT_TYPEHASH",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "bytes32", "internalType": "bytes32" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "allowance",
-        "inputs": [
-            { "name": "owner", "type": "address", "internalType": "address" },
-            { "name": "spender", "type": "address", "internalType": "address" }
-        ],
-        "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "approve",
-        "inputs": [
-            { "name": "spender", "type": "address", "internalType": "address" },
-            { "name": "value", "type": "uint256", "internalType": "uint256" }
-        ],
-        "outputs": [{ "name": "", "type": "bool", "internalType": "bool" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "balanceOf",
-        "inputs": [{ "name": "account", "type": "address", "internalType": "address" }],
-        "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "decimals",
-        "inputs": [],
-        "outputs": [{ "name": "decimals_", "type": "uint8", "internalType": "uint8" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "deposit",
-        "inputs": [{ "name": "amount_", "type": "uint256", "internalType": "uint256" }],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "depositFor",
-        "inputs": [
-            { "name": "recipient_", "type": "address", "internalType": "address" },
-            { "name": "amount_", "type": "uint256", "internalType": "uint256" }
-        ],
-        "outputs": [{ "name": "success_", "type": "bool", "internalType": "bool" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "depositForWithPermit",
-        "inputs": [
-            { "name": "recipient_", "type": "address", "internalType": "address" },
-            { "name": "amount_", "type": "uint256", "internalType": "uint256" },
-            { "name": "deadline_", "type": "uint256", "internalType": "uint256" },
-            { "name": "v_", "type": "uint8", "internalType": "uint8" },
-            { "name": "r_", "type": "bytes32", "internalType": "bytes32" },
-            { "name": "s_", "type": "bytes32", "internalType": "bytes32" }
-        ],
-        "outputs": [{ "name": "success_", "type": "bool", "internalType": "bool" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "depositWithPermit",
-        "inputs": [
-            { "name": "amount_", "type": "uint256", "internalType": "uint256" },
-            { "name": "deadline_", "type": "uint256", "internalType": "uint256" },
-            { "name": "v_", "type": "uint8", "internalType": "uint8" },
-            { "name": "r_", "type": "bytes32", "internalType": "bytes32" },
-            { "name": "s_", "type": "bytes32", "internalType": "bytes32" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "eip712Domain",
-        "inputs": [],
-        "outputs": [
-            { "name": "fields", "type": "bytes1", "internalType": "bytes1" },
-            { "name": "name", "type": "string", "internalType": "string" },
-            { "name": "version", "type": "string", "internalType": "string" },
-            { "name": "chainId", "type": "uint256", "internalType": "uint256" },
-            { "name": "verifyingContract", "type": "address", "internalType": "address" },
-            { "name": "salt", "type": "bytes32", "internalType": "bytes32" },
-            { "name": "extensions", "type": "uint256[]", "internalType": "uint256[]" }
-        ],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "getPermitDigest",
-        "inputs": [
-            { "name": "owner_", "type": "address", "internalType": "address" },
-            { "name": "spender_", "type": "address", "internalType": "address" },
-            { "name": "value_", "type": "uint256", "internalType": "uint256" },
-            { "name": "nonce_", "type": "uint256", "internalType": "uint256" },
-            { "name": "deadline_", "type": "uint256", "internalType": "uint256" }
-        ],
-        "outputs": [{ "name": "digest_", "type": "bytes32", "internalType": "bytes32" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "implementation",
-        "inputs": [],
-        "outputs": [{ "name": "implementation_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    { "type": "function", "name": "initialize", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    { "type": "function", "name": "migrate", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "migratorParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "parameterRegistry_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "underlying_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "DOMAIN_SEPARATOR",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "domainSeparator_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "PERMIT_TYPEHASH",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "allowance",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "spender",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "approve",
+    "inputs": [
+      {
+        "name": "spender",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "balanceOf",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "decimals",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "decimals_",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "deposit",
+    "inputs": [
+      {
+        "name": "amount_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "depositFor",
+    "inputs": [
+      {
+        "name": "recipient_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "success_",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "depositForWithPermit",
+    "inputs": [
+      {
+        "name": "recipient_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "deadline_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "v_",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "r_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "s_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "success_",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "depositWithPermit",
+    "inputs": [
+      {
+        "name": "amount_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "deadline_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "v_",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "r_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "s_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "eip712Domain",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "fields",
+        "type": "bytes1",
+        "internalType": "bytes1"
+      },
+      {
         "name": "name",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "string", "internalType": "string" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "nonces",
-        "inputs": [{ "name": "owner_", "type": "address", "internalType": "address" }],
-        "outputs": [{ "name": "nonce_", "type": "uint256", "internalType": "uint256" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "parameterRegistry",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "permit",
-        "inputs": [
-            { "name": "owner_", "type": "address", "internalType": "address" },
-            { "name": "spender_", "type": "address", "internalType": "address" },
-            { "name": "value_", "type": "uint256", "internalType": "uint256" },
-            { "name": "deadline_", "type": "uint256", "internalType": "uint256" },
-            { "name": "v_", "type": "uint8", "internalType": "uint8" },
-            { "name": "r_", "type": "bytes32", "internalType": "bytes32" },
-            { "name": "s_", "type": "bytes32", "internalType": "bytes32" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "symbol",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "string", "internalType": "string" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "totalSupply",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "transfer",
-        "inputs": [
-            { "name": "to", "type": "address", "internalType": "address" },
-            { "name": "value", "type": "uint256", "internalType": "uint256" }
-        ],
-        "outputs": [{ "name": "", "type": "bool", "internalType": "bool" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "transferFrom",
-        "inputs": [
-            { "name": "from", "type": "address", "internalType": "address" },
-            { "name": "to", "type": "address", "internalType": "address" },
-            { "name": "value", "type": "uint256", "internalType": "uint256" }
-        ],
-        "outputs": [{ "name": "", "type": "bool", "internalType": "bool" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "underlying",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "withdraw",
-        "inputs": [{ "name": "amount_", "type": "uint256", "internalType": "uint256" }],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "withdrawTo",
-        "inputs": [
-            { "name": "recipient_", "type": "address", "internalType": "address" },
-            { "name": "amount_", "type": "uint256", "internalType": "uint256" }
-        ],
-        "outputs": [{ "name": "success_", "type": "bool", "internalType": "bool" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "event",
-        "name": "Approval",
-        "inputs": [
-            { "name": "owner", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "spender", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "value", "type": "uint256", "indexed": false, "internalType": "uint256" }
-        ],
-        "anonymous": false
-    },
-    { "type": "event", "name": "EIP712DomainChanged", "inputs": [], "anonymous": false },
-    {
-        "type": "event",
-        "name": "Initialized",
-        "inputs": [{ "name": "version", "type": "uint64", "indexed": false, "internalType": "uint64" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Migrated",
-        "inputs": [{ "name": "migrator", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Transfer",
-        "inputs": [
-            { "name": "from", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "to", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "value", "type": "uint256", "indexed": false, "internalType": "uint256" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Upgraded",
-        "inputs": [{ "name": "implementation", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    { "type": "error", "name": "ECDSAInvalidSignature", "inputs": [] },
-    {
-        "type": "error",
-        "name": "ECDSAInvalidSignatureLength",
-        "inputs": [{ "name": "length", "type": "uint256", "internalType": "uint256" }]
-    },
-    {
-        "type": "error",
-        "name": "ECDSAInvalidSignatureS",
-        "inputs": [{ "name": "s", "type": "bytes32", "internalType": "bytes32" }]
-    },
-    {
-        "type": "error",
-        "name": "ERC20InsufficientAllowance",
-        "inputs": [
-            { "name": "spender", "type": "address", "internalType": "address" },
-            { "name": "allowance", "type": "uint256", "internalType": "uint256" },
-            { "name": "needed", "type": "uint256", "internalType": "uint256" }
-        ]
-    },
-    {
-        "type": "error",
-        "name": "ERC20InsufficientBalance",
-        "inputs": [
-            { "name": "sender", "type": "address", "internalType": "address" },
-            { "name": "balance", "type": "uint256", "internalType": "uint256" },
-            { "name": "needed", "type": "uint256", "internalType": "uint256" }
-        ]
-    },
-    {
-        "type": "error",
-        "name": "ERC20InvalidApprover",
-        "inputs": [{ "name": "approver", "type": "address", "internalType": "address" }]
-    },
-    {
-        "type": "error",
-        "name": "ERC20InvalidReceiver",
-        "inputs": [{ "name": "receiver", "type": "address", "internalType": "address" }]
-    },
-    {
-        "type": "error",
-        "name": "ERC20InvalidSender",
-        "inputs": [{ "name": "sender", "type": "address", "internalType": "address" }]
-    },
-    {
-        "type": "error",
-        "name": "ERC20InvalidSpender",
-        "inputs": [{ "name": "spender", "type": "address", "internalType": "address" }]
-    },
-    {
-        "type": "error",
-        "name": "ERC2612ExpiredSignature",
-        "inputs": [{ "name": "deadline", "type": "uint256", "internalType": "uint256" }]
-    },
-    {
-        "type": "error",
-        "name": "ERC2612InvalidSigner",
-        "inputs": [
-            { "name": "signer", "type": "address", "internalType": "address" },
-            { "name": "owner", "type": "address", "internalType": "address" }
-        ]
-    },
-    {
-        "type": "error",
-        "name": "EmptyCode",
-        "inputs": [{ "name": "migrator_", "type": "address", "internalType": "address" }]
-    },
-    {
-        "type": "error",
-        "name": "InvalidAccountNonce",
-        "inputs": [
-            { "name": "account", "type": "address", "internalType": "address" },
-            { "name": "currentNonce", "type": "uint256", "internalType": "uint256" }
-        ]
-    },
-    { "type": "error", "name": "InvalidInitialization", "inputs": [] },
-    {
-        "type": "error",
-        "name": "MigrationFailed",
-        "inputs": [
-            { "name": "migrator_", "type": "address", "internalType": "address" },
-            { "name": "revertData_", "type": "bytes", "internalType": "bytes" }
-        ]
-    },
-    { "type": "error", "name": "NotInitializing", "inputs": [] },
-    { "type": "error", "name": "ParameterOutOfTypeBounds", "inputs": [] },
-    { "type": "error", "name": "TransferFailed", "inputs": [] },
-    { "type": "error", "name": "TransferFromFailed", "inputs": [] },
-    { "type": "error", "name": "ZeroAmount", "inputs": [] },
-    { "type": "error", "name": "ZeroMigrator", "inputs": [] },
-    { "type": "error", "name": "ZeroParameterRegistry", "inputs": [] },
-    { "type": "error", "name": "ZeroRecipient", "inputs": [] },
-    { "type": "error", "name": "ZeroUnderlying", "inputs": [] }
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "version",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "chainId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "verifyingContract",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "salt",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "extensions",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getPermitDigest",
+    "inputs": [
+      {
+        "name": "owner_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "spender_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "value_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "nonce_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "deadline_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "digest_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "implementation",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "implementation_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "migrate",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "migratorParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "name",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "nonces",
+    "inputs": [
+      {
+        "name": "owner_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "nonce_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "parameterRegistry",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "permit",
+    "inputs": [
+      {
+        "name": "owner_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "spender_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "value_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "deadline_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "v_",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "r_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "s_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "symbol",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "totalSupply",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "transfer",
+    "inputs": [
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "transferFrom",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "underlying",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "withdraw",
+    "inputs": [
+      {
+        "name": "amount_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "withdrawTo",
+    "inputs": [
+      {
+        "name": "recipient_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "success_",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "Approval",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "spender",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "EIP712DomainChanged",
+    "inputs": [],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Migrated",
+    "inputs": [
+      {
+        "name": "migrator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Transfer",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "ECDSAInvalidSignature",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ECDSAInvalidSignatureLength",
+    "inputs": [
+      {
+        "name": "length",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ECDSAInvalidSignatureS",
+    "inputs": [
+      {
+        "name": "s",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC20InsufficientAllowance",
+    "inputs": [
+      {
+        "name": "spender",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "allowance",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "needed",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC20InsufficientBalance",
+    "inputs": [
+      {
+        "name": "sender",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "balance",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "needed",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC20InvalidApprover",
+    "inputs": [
+      {
+        "name": "approver",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC20InvalidReceiver",
+    "inputs": [
+      {
+        "name": "receiver",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC20InvalidSender",
+    "inputs": [
+      {
+        "name": "sender",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC20InvalidSpender",
+    "inputs": [
+      {
+        "name": "spender",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC2612ExpiredSignature",
+    "inputs": [
+      {
+        "name": "deadline",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC2612InvalidSigner",
+    "inputs": [
+      {
+        "name": "signer",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "EmptyCode",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InvalidAccountNonce",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "currentNonce",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InvalidInitialization",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MigrationFailed",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "revertData_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ParameterOutOfTypeBounds",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "TransferFailed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "TransferFromFailed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroAmount",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroMigrator",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroParameterRegistry",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroRecipient",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroUnderlying",
+    "inputs": []
+  }
 ]

--- a/settlement-chain/abis/NodeRegistry.abi.json
+++ b/settlement-chain/abis/NodeRegistry.abi.json
@@ -1,481 +1,1093 @@
 [
-    {
-        "type": "constructor",
-        "inputs": [{ "name": "parameterRegistry_", "type": "address", "internalType": "address" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "NODE_INCREMENT",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "uint32", "internalType": "uint32" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "addNode",
-        "inputs": [
-            { "name": "owner_", "type": "address", "internalType": "address" },
-            { "name": "signingPublicKey_", "type": "bytes", "internalType": "bytes" },
-            { "name": "httpAddress_", "type": "string", "internalType": "string" }
-        ],
-        "outputs": [
-            { "name": "nodeId_", "type": "uint32", "internalType": "uint32" },
-            { "name": "signer_", "type": "address", "internalType": "address" }
-        ],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "addToNetwork",
-        "inputs": [{ "name": "nodeId_", "type": "uint32", "internalType": "uint32" }],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "parameterRegistry_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "NODE_INCREMENT",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "addNode",
+    "inputs": [
+      {
+        "name": "owner_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "signingPublicKey_",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "httpAddress_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "nodeId_",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "signer_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "addToNetwork",
+    "inputs": [
+      {
+        "name": "nodeId_",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "admin",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "admin_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "adminParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "approve",
+    "inputs": [
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "balanceOf",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "canonicalNodesCount",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "canonicalNodesCount_",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getAllNodes",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "allNodes_",
+        "type": "tuple[]",
+        "internalType": "struct INodeRegistry.NodeWithId[]",
+        "components": [
+          {
+            "name": "nodeId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "node",
+            "type": "tuple",
+            "internalType": "struct INodeRegistry.Node",
+            "components": [
+              {
+                "name": "signer",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "isCanonical",
+                "type": "bool",
+                "internalType": "bool"
+              },
+              {
+                "name": "signingPublicKey",
+                "type": "bytes",
+                "internalType": "bytes"
+              },
+              {
+                "name": "httpAddress",
+                "type": "string",
+                "internalType": "string"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getAllNodesCount",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "nodeCount_",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getApproved",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getIsCanonicalNode",
+    "inputs": [
+      {
+        "name": "nodeId_",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "isCanonicalNode_",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getNode",
+    "inputs": [
+      {
+        "name": "nodeId_",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "node_",
+        "type": "tuple",
+        "internalType": "struct INodeRegistry.Node",
+        "components": [
+          {
+            "name": "signer",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "isCanonical",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "signingPublicKey",
+            "type": "bytes",
+            "internalType": "bytes"
+          },
+          {
+            "name": "httpAddress",
+            "type": "string",
+            "internalType": "string"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getSigner",
+    "inputs": [
+      {
+        "name": "nodeId_",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "signer_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "implementation",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "implementation_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "isApprovedForAll",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "maxCanonicalNodes",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "maxCanonicalNodes_",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "maxCanonicalNodesParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "migrate",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "migratorParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "name",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "ownerOf",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "parameterRegistry",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "removeFromNetwork",
+    "inputs": [
+      {
+        "name": "nodeId_",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "safeTransferFrom",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "safeTransferFrom",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "data",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setApprovalForAll",
+    "inputs": [
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "approved",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setBaseURI",
+    "inputs": [
+      {
+        "name": "baseURI_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setHttpAddress",
+    "inputs": [
+      {
+        "name": "nodeId_",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "httpAddress_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "supportsInterface",
+    "inputs": [
+      {
+        "name": "interfaceId",
+        "type": "bytes4",
+        "internalType": "bytes4"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "symbol",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "tokenURI",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "transferFrom",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateAdmin",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateMaxCanonicalNodes",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "AdminUpdated",
+    "inputs": [
+      {
         "name": "admin",
-        "inputs": [],
-        "outputs": [{ "name": "admin_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "adminParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "approve",
-        "inputs": [
-            { "name": "to", "type": "address", "internalType": "address" },
-            { "name": "tokenId", "type": "uint256", "internalType": "uint256" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "balanceOf",
-        "inputs": [{ "name": "owner", "type": "address", "internalType": "address" }],
-        "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "canonicalNodesCount",
-        "inputs": [],
-        "outputs": [{ "name": "canonicalNodesCount_", "type": "uint8", "internalType": "uint8" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "getAllNodes",
-        "inputs": [],
-        "outputs": [
-            {
-                "name": "allNodes_",
-                "type": "tuple[]",
-                "internalType": "struct INodeRegistry.NodeWithId[]",
-                "components": [
-                    { "name": "nodeId", "type": "uint32", "internalType": "uint32" },
-                    {
-                        "name": "node",
-                        "type": "tuple",
-                        "internalType": "struct INodeRegistry.Node",
-                        "components": [
-                            { "name": "signer", "type": "address", "internalType": "address" },
-                            { "name": "isCanonical", "type": "bool", "internalType": "bool" },
-                            { "name": "signingPublicKey", "type": "bytes", "internalType": "bytes" },
-                            { "name": "httpAddress", "type": "string", "internalType": "string" }
-                        ]
-                    }
-                ]
-            }
-        ],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "getAllNodesCount",
-        "inputs": [],
-        "outputs": [{ "name": "nodeCount_", "type": "uint32", "internalType": "uint32" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "getApproved",
-        "inputs": [{ "name": "tokenId", "type": "uint256", "internalType": "uint256" }],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "getIsCanonicalNode",
-        "inputs": [{ "name": "nodeId_", "type": "uint32", "internalType": "uint32" }],
-        "outputs": [{ "name": "isCanonicalNode_", "type": "bool", "internalType": "bool" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "getNode",
-        "inputs": [{ "name": "nodeId_", "type": "uint32", "internalType": "uint32" }],
-        "outputs": [
-            {
-                "name": "node_",
-                "type": "tuple",
-                "internalType": "struct INodeRegistry.Node",
-                "components": [
-                    { "name": "signer", "type": "address", "internalType": "address" },
-                    { "name": "isCanonical", "type": "bool", "internalType": "bool" },
-                    { "name": "signingPublicKey", "type": "bytes", "internalType": "bytes" },
-                    { "name": "httpAddress", "type": "string", "internalType": "string" }
-                ]
-            }
-        ],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "getSigner",
-        "inputs": [{ "name": "nodeId_", "type": "uint32", "internalType": "uint32" }],
-        "outputs": [{ "name": "signer_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "implementation",
-        "inputs": [],
-        "outputs": [{ "name": "implementation_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    { "type": "function", "name": "initialize", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "isApprovedForAll",
-        "inputs": [
-            { "name": "owner", "type": "address", "internalType": "address" },
-            { "name": "operator", "type": "address", "internalType": "address" }
-        ],
-        "outputs": [{ "name": "", "type": "bool", "internalType": "bool" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Approval",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "approved",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ApprovalForAll",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "approved",
+        "type": "bool",
+        "indexed": false,
+        "internalType": "bool"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "BaseURIUpdated",
+    "inputs": [
+      {
+        "name": "baseURI",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "HttpAddressUpdated",
+    "inputs": [
+      {
+        "name": "nodeId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "httpAddress",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "MaxCanonicalNodesUpdated",
+    "inputs": [
+      {
         "name": "maxCanonicalNodes",
-        "inputs": [],
-        "outputs": [{ "name": "maxCanonicalNodes_", "type": "uint8", "internalType": "uint8" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "maxCanonicalNodesParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    { "type": "function", "name": "migrate", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "migratorParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "name",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "string", "internalType": "string" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "ownerOf",
-        "inputs": [{ "name": "tokenId", "type": "uint256", "internalType": "uint256" }],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "parameterRegistry",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "removeFromNetwork",
-        "inputs": [{ "name": "nodeId_", "type": "uint32", "internalType": "uint32" }],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "safeTransferFrom",
-        "inputs": [
-            { "name": "from", "type": "address", "internalType": "address" },
-            { "name": "to", "type": "address", "internalType": "address" },
-            { "name": "tokenId", "type": "uint256", "internalType": "uint256" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "safeTransferFrom",
-        "inputs": [
-            { "name": "from", "type": "address", "internalType": "address" },
-            { "name": "to", "type": "address", "internalType": "address" },
-            { "name": "tokenId", "type": "uint256", "internalType": "uint256" },
-            { "name": "data", "type": "bytes", "internalType": "bytes" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "setApprovalForAll",
-        "inputs": [
-            { "name": "operator", "type": "address", "internalType": "address" },
-            { "name": "approved", "type": "bool", "internalType": "bool" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "setBaseURI",
-        "inputs": [{ "name": "baseURI_", "type": "string", "internalType": "string" }],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "setHttpAddress",
-        "inputs": [
-            { "name": "nodeId_", "type": "uint32", "internalType": "uint32" },
-            { "name": "httpAddress_", "type": "string", "internalType": "string" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "supportsInterface",
-        "inputs": [{ "name": "interfaceId", "type": "bytes4", "internalType": "bytes4" }],
-        "outputs": [{ "name": "", "type": "bool", "internalType": "bool" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "symbol",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "string", "internalType": "string" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "tokenURI",
-        "inputs": [{ "name": "tokenId", "type": "uint256", "internalType": "uint256" }],
-        "outputs": [{ "name": "", "type": "string", "internalType": "string" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "transferFrom",
-        "inputs": [
-            { "name": "from", "type": "address", "internalType": "address" },
-            { "name": "to", "type": "address", "internalType": "address" },
-            { "name": "tokenId", "type": "uint256", "internalType": "uint256" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    { "type": "function", "name": "updateAdmin", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "updateMaxCanonicalNodes",
-        "inputs": [],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "event",
-        "name": "AdminUpdated",
-        "inputs": [{ "name": "admin", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Approval",
-        "inputs": [
-            { "name": "owner", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "approved", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "tokenId", "type": "uint256", "indexed": true, "internalType": "uint256" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "ApprovalForAll",
-        "inputs": [
-            { "name": "owner", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "operator", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "approved", "type": "bool", "indexed": false, "internalType": "bool" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "BaseURIUpdated",
-        "inputs": [{ "name": "baseURI", "type": "string", "indexed": false, "internalType": "string" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "HttpAddressUpdated",
-        "inputs": [
-            { "name": "nodeId", "type": "uint32", "indexed": true, "internalType": "uint32" },
-            { "name": "httpAddress", "type": "string", "indexed": false, "internalType": "string" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Initialized",
-        "inputs": [{ "name": "version", "type": "uint64", "indexed": false, "internalType": "uint64" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "MaxCanonicalNodesUpdated",
-        "inputs": [{ "name": "maxCanonicalNodes", "type": "uint8", "indexed": false, "internalType": "uint8" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Migrated",
-        "inputs": [{ "name": "migrator", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "NodeAdded",
-        "inputs": [
-            { "name": "nodeId", "type": "uint32", "indexed": true, "internalType": "uint32" },
-            { "name": "owner", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "signer", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "signingPublicKey", "type": "bytes", "indexed": false, "internalType": "bytes" },
-            { "name": "httpAddress", "type": "string", "indexed": false, "internalType": "string" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "NodeAddedToCanonicalNetwork",
-        "inputs": [{ "name": "nodeId", "type": "uint32", "indexed": true, "internalType": "uint32" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "NodeRemovedFromCanonicalNetwork",
-        "inputs": [{ "name": "nodeId", "type": "uint32", "indexed": true, "internalType": "uint32" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Transfer",
-        "inputs": [
-            { "name": "from", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "to", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "tokenId", "type": "uint256", "indexed": true, "internalType": "uint256" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Upgraded",
-        "inputs": [{ "name": "implementation", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "error",
-        "name": "ERC721IncorrectOwner",
-        "inputs": [
-            { "name": "sender", "type": "address", "internalType": "address" },
-            { "name": "tokenId", "type": "uint256", "internalType": "uint256" },
-            { "name": "owner", "type": "address", "internalType": "address" }
-        ]
-    },
-    {
-        "type": "error",
-        "name": "ERC721InsufficientApproval",
-        "inputs": [
-            { "name": "operator", "type": "address", "internalType": "address" },
-            { "name": "tokenId", "type": "uint256", "internalType": "uint256" }
-        ]
-    },
-    {
-        "type": "error",
-        "name": "ERC721InvalidApprover",
-        "inputs": [{ "name": "approver", "type": "address", "internalType": "address" }]
-    },
-    {
-        "type": "error",
-        "name": "ERC721InvalidOperator",
-        "inputs": [{ "name": "operator", "type": "address", "internalType": "address" }]
-    },
-    {
-        "type": "error",
-        "name": "ERC721InvalidOwner",
-        "inputs": [{ "name": "owner", "type": "address", "internalType": "address" }]
-    },
-    {
-        "type": "error",
-        "name": "ERC721InvalidReceiver",
-        "inputs": [{ "name": "receiver", "type": "address", "internalType": "address" }]
-    },
-    {
-        "type": "error",
-        "name": "ERC721InvalidSender",
-        "inputs": [{ "name": "sender", "type": "address", "internalType": "address" }]
-    },
-    {
-        "type": "error",
-        "name": "ERC721NonexistentToken",
-        "inputs": [{ "name": "tokenId", "type": "uint256", "internalType": "uint256" }]
-    },
-    {
-        "type": "error",
-        "name": "EmptyCode",
-        "inputs": [{ "name": "migrator_", "type": "address", "internalType": "address" }]
-    },
-    { "type": "error", "name": "FailedToAddNodeToCanonicalNetwork", "inputs": [] },
-    { "type": "error", "name": "FailedToRemoveNodeFromCanonicalNetwork", "inputs": [] },
-    { "type": "error", "name": "InvalidHttpAddress", "inputs": [] },
-    { "type": "error", "name": "InvalidInitialization", "inputs": [] },
-    { "type": "error", "name": "InvalidOwner", "inputs": [] },
-    { "type": "error", "name": "InvalidSigningPublicKey", "inputs": [] },
-    { "type": "error", "name": "InvalidURI", "inputs": [] },
-    { "type": "error", "name": "MaxCanonicalNodesBelowCurrentCount", "inputs": [] },
-    { "type": "error", "name": "MaxCanonicalNodesReached", "inputs": [] },
-    { "type": "error", "name": "MaxNodesReached", "inputs": [] },
-    {
-        "type": "error",
-        "name": "MigrationFailed",
-        "inputs": [
-            { "name": "migrator_", "type": "address", "internalType": "address" },
-            { "name": "revertData_", "type": "bytes", "internalType": "bytes" }
-        ]
-    },
-    { "type": "error", "name": "NoChange", "inputs": [] },
-    { "type": "error", "name": "NotAdmin", "inputs": [] },
-    { "type": "error", "name": "NotInitializing", "inputs": [] },
-    { "type": "error", "name": "NotNodeOwner", "inputs": [] },
-    { "type": "error", "name": "ParameterOutOfTypeBounds", "inputs": [] },
-    { "type": "error", "name": "ZeroMigrator", "inputs": [] },
-    { "type": "error", "name": "ZeroParameterRegistry", "inputs": [] }
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Migrated",
+    "inputs": [
+      {
+        "name": "migrator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "NodeAdded",
+    "inputs": [
+      {
+        "name": "nodeId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "signer",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "signingPublicKey",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      },
+      {
+        "name": "httpAddress",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "NodeAddedToCanonicalNetwork",
+    "inputs": [
+      {
+        "name": "nodeId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "NodeRemovedFromCanonicalNetwork",
+    "inputs": [
+      {
+        "name": "nodeId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Transfer",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "ERC721IncorrectOwner",
+    "inputs": [
+      {
+        "name": "sender",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC721InsufficientApproval",
+    "inputs": [
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC721InvalidApprover",
+    "inputs": [
+      {
+        "name": "approver",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC721InvalidOperator",
+    "inputs": [
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC721InvalidOwner",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC721InvalidReceiver",
+    "inputs": [
+      {
+        "name": "receiver",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC721InvalidSender",
+    "inputs": [
+      {
+        "name": "sender",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC721NonexistentToken",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "EmptyCode",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "FailedToAddNodeToCanonicalNetwork",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "FailedToRemoveNodeFromCanonicalNetwork",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidHttpAddress",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidInitialization",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidOwner",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidSigningPublicKey",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidURI",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MaxCanonicalNodesBelowCurrentCount",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MaxCanonicalNodesReached",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MaxNodesReached",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MigrationFailed",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "revertData_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "NoChange",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotAdmin",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotNodeOwner",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ParameterOutOfTypeBounds",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroMigrator",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroParameterRegistry",
+    "inputs": []
+  }
 ]

--- a/settlement-chain/abis/PayerRegistry.abi.json
+++ b/settlement-chain/abis/PayerRegistry.abi.json
@@ -1,423 +1,935 @@
 [
-    {
-        "type": "constructor",
-        "inputs": [
-            { "name": "parameterRegistry_", "type": "address", "internalType": "address" },
-            { "name": "feeToken_", "type": "address", "internalType": "address" }
-        ],
-        "stateMutability": "nonpayable"
-    },
-    { "type": "function", "name": "cancelWithdrawal", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "deposit",
-        "inputs": [
-            { "name": "payer_", "type": "address", "internalType": "address" },
-            { "name": "amount_", "type": "uint96", "internalType": "uint96" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "depositFromUnderlying",
-        "inputs": [
-            { "name": "payer_", "type": "address", "internalType": "address" },
-            { "name": "amount_", "type": "uint96", "internalType": "uint96" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "depositFromUnderlyingWithPermit",
-        "inputs": [
-            { "name": "payer_", "type": "address", "internalType": "address" },
-            { "name": "amount_", "type": "uint96", "internalType": "uint96" },
-            { "name": "deadline_", "type": "uint256", "internalType": "uint256" },
-            { "name": "v_", "type": "uint8", "internalType": "uint8" },
-            { "name": "r_", "type": "bytes32", "internalType": "bytes32" },
-            { "name": "s_", "type": "bytes32", "internalType": "bytes32" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "depositWithPermit",
-        "inputs": [
-            { "name": "payer_", "type": "address", "internalType": "address" },
-            { "name": "amount_", "type": "uint96", "internalType": "uint96" },
-            { "name": "deadline_", "type": "uint256", "internalType": "uint256" },
-            { "name": "v_", "type": "uint8", "internalType": "uint8" },
-            { "name": "r_", "type": "bytes32", "internalType": "bytes32" },
-            { "name": "s_", "type": "bytes32", "internalType": "bytes32" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "excess",
-        "inputs": [],
-        "outputs": [{ "name": "excess_", "type": "uint96", "internalType": "uint96" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "parameterRegistry_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "feeToken_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "cancelWithdrawal",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "deposit",
+    "inputs": [
+      {
+        "name": "payer_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount_",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "depositFromUnderlying",
+    "inputs": [
+      {
+        "name": "payer_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount_",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "depositFromUnderlyingWithPermit",
+    "inputs": [
+      {
+        "name": "payer_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount_",
+        "type": "uint96",
+        "internalType": "uint96"
+      },
+      {
+        "name": "deadline_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "v_",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "r_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "s_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "depositWithPermit",
+    "inputs": [
+      {
+        "name": "payer_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount_",
+        "type": "uint96",
+        "internalType": "uint96"
+      },
+      {
+        "name": "deadline_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "v_",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "r_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "s_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "excess",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "excess_",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "feeDistributor",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "feeDistributor_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "feeDistributorParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "feeToken",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "finalizeWithdrawal",
+    "inputs": [
+      {
+        "name": "recipient_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "finalizeWithdrawalIntoUnderlying",
+    "inputs": [
+      {
+        "name": "recipient_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "getBalance",
+    "inputs": [
+      {
+        "name": "payer_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "balance_",
+        "type": "int104",
+        "internalType": "int104"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getBalances",
+    "inputs": [
+      {
+        "name": "payers_",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "balances_",
+        "type": "int104[]",
+        "internalType": "int104[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getPendingWithdrawal",
+    "inputs": [
+      {
+        "name": "payer_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "pendingWithdrawal_",
+        "type": "uint96",
+        "internalType": "uint96"
+      },
+      {
+        "name": "withdrawableTimestamp_",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "implementation",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "implementation_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "migrate",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "migratorParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "minimumDeposit",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "minimumDeposit_",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "minimumDepositParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "parameterRegistry",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "paused",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "paused_",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "pausedParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "requestWithdrawal",
+    "inputs": [
+      {
+        "name": "amount_",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "sendExcessToFeeDistributor",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "excess_",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "settleUsage",
+    "inputs": [
+      {
+        "name": "payerFees_",
+        "type": "tuple[]",
+        "internalType": "struct IPayerRegistry.PayerFee[]",
+        "components": [
+          {
+            "name": "payer",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "fee",
+            "type": "uint96",
+            "internalType": "uint96"
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "feesSettled_",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "settler",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "settler_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "settlerParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "totalDebt",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "totalDebt_",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "totalDeposits",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "totalDeposits_",
+        "type": "int104",
+        "internalType": "int104"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "totalWithdrawable",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "totalWithdrawable_",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "updateFeeDistributor",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateMinimumDeposit",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updatePauseStatus",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateSettler",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateWithdrawLockPeriod",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "withdrawLockPeriod",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "withdrawLockPeriod_",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "withdrawLockPeriodParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "event",
+    "name": "Deposit",
+    "inputs": [
+      {
+        "name": "payer",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint96",
+        "indexed": false,
+        "internalType": "uint96"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ExcessTransferred",
+    "inputs": [
+      {
+        "name": "amount",
+        "type": "uint96",
+        "indexed": false,
+        "internalType": "uint96"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "FeeDistributorUpdated",
+    "inputs": [
+      {
         "name": "feeDistributor",
-        "inputs": [],
-        "outputs": [{ "name": "feeDistributor_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "feeDistributorParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "feeToken",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "finalizeWithdrawal",
-        "inputs": [{ "name": "recipient_", "type": "address", "internalType": "address" }],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "finalizeWithdrawalIntoUnderlying",
-        "inputs": [{ "name": "recipient_", "type": "address", "internalType": "address" }],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "getBalance",
-        "inputs": [{ "name": "payer_", "type": "address", "internalType": "address" }],
-        "outputs": [{ "name": "balance_", "type": "int104", "internalType": "int104" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "getBalances",
-        "inputs": [{ "name": "payers_", "type": "address[]", "internalType": "address[]" }],
-        "outputs": [{ "name": "balances_", "type": "int104[]", "internalType": "int104[]" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "getPendingWithdrawal",
-        "inputs": [{ "name": "payer_", "type": "address", "internalType": "address" }],
-        "outputs": [
-            { "name": "pendingWithdrawal_", "type": "uint96", "internalType": "uint96" },
-            { "name": "withdrawableTimestamp_", "type": "uint32", "internalType": "uint32" }
-        ],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "implementation",
-        "inputs": [],
-        "outputs": [{ "name": "implementation_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    { "type": "function", "name": "initialize", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    { "type": "function", "name": "migrate", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "migratorParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Migrated",
+    "inputs": [
+      {
+        "name": "migrator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "MinimumDepositUpdated",
+    "inputs": [
+      {
         "name": "minimumDeposit",
-        "inputs": [],
-        "outputs": [{ "name": "minimumDeposit_", "type": "uint96", "internalType": "uint96" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "minimumDepositParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "parameterRegistry",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
+        "type": "uint96",
+        "indexed": false,
+        "internalType": "uint96"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PauseStatusUpdated",
+    "inputs": [
+      {
         "name": "paused",
-        "inputs": [],
-        "outputs": [{ "name": "paused_", "type": "bool", "internalType": "bool" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "pausedParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "requestWithdrawal",
-        "inputs": [{ "name": "amount_", "type": "uint96", "internalType": "uint96" }],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "sendExcessToFeeDistributor",
-        "inputs": [],
-        "outputs": [{ "name": "excess_", "type": "uint96", "internalType": "uint96" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "settleUsage",
-        "inputs": [
-            {
-                "name": "payerFees_",
-                "type": "tuple[]",
-                "internalType": "struct IPayerRegistry.PayerFee[]",
-                "components": [
-                    { "name": "payer", "type": "address", "internalType": "address" },
-                    { "name": "fee", "type": "uint96", "internalType": "uint96" }
-                ]
-            }
-        ],
-        "outputs": [{ "name": "feesSettled_", "type": "uint96", "internalType": "uint96" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
+        "type": "bool",
+        "indexed": true,
+        "internalType": "bool"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "SettlerUpdated",
+    "inputs": [
+      {
         "name": "settler",
-        "inputs": [],
-        "outputs": [{ "name": "settler_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "settlerParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "totalDebt",
-        "inputs": [],
-        "outputs": [{ "name": "totalDebt_", "type": "uint96", "internalType": "uint96" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "totalDeposits",
-        "inputs": [],
-        "outputs": [{ "name": "totalDeposits_", "type": "int104", "internalType": "int104" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "totalWithdrawable",
-        "inputs": [],
-        "outputs": [{ "name": "totalWithdrawable_", "type": "uint96", "internalType": "uint96" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "updateFeeDistributor",
-        "inputs": [],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "updateMinimumDeposit",
-        "inputs": [],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    { "type": "function", "name": "updatePauseStatus", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    { "type": "function", "name": "updateSettler", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "updateWithdrawLockPeriod",
-        "inputs": [],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "UsageSettled",
+    "inputs": [
+      {
+        "name": "payer",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint96",
+        "indexed": false,
+        "internalType": "uint96"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "WithdrawLockPeriodUpdated",
+    "inputs": [
+      {
         "name": "withdrawLockPeriod",
-        "inputs": [],
-        "outputs": [{ "name": "withdrawLockPeriod_", "type": "uint32", "internalType": "uint32" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "withdrawLockPeriodParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "event",
-        "name": "Deposit",
-        "inputs": [
-            { "name": "payer", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "amount", "type": "uint96", "indexed": false, "internalType": "uint96" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "ExcessTransferred",
-        "inputs": [{ "name": "amount", "type": "uint96", "indexed": false, "internalType": "uint96" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "FeeDistributorUpdated",
-        "inputs": [{ "name": "feeDistributor", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Initialized",
-        "inputs": [{ "name": "version", "type": "uint64", "indexed": false, "internalType": "uint64" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Migrated",
-        "inputs": [{ "name": "migrator", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "MinimumDepositUpdated",
-        "inputs": [{ "name": "minimumDeposit", "type": "uint96", "indexed": false, "internalType": "uint96" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "PauseStatusUpdated",
-        "inputs": [{ "name": "paused", "type": "bool", "indexed": true, "internalType": "bool" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "SettlerUpdated",
-        "inputs": [{ "name": "settler", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Upgraded",
-        "inputs": [{ "name": "implementation", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "UsageSettled",
-        "inputs": [
-            { "name": "payer", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "amount", "type": "uint96", "indexed": false, "internalType": "uint96" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "WithdrawLockPeriodUpdated",
-        "inputs": [{ "name": "withdrawLockPeriod", "type": "uint32", "indexed": false, "internalType": "uint32" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "WithdrawalCancelled",
-        "inputs": [{ "name": "payer", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "WithdrawalFinalized",
-        "inputs": [{ "name": "payer", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "WithdrawalRequested",
-        "inputs": [
-            { "name": "payer", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "amount", "type": "uint96", "indexed": false, "internalType": "uint96" },
-            { "name": "withdrawableTimestamp", "type": "uint32", "indexed": false, "internalType": "uint32" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "error",
-        "name": "EmptyCode",
-        "inputs": [{ "name": "migrator_", "type": "address", "internalType": "address" }]
-    },
-    { "type": "error", "name": "InsufficientBalance", "inputs": [] },
-    {
-        "type": "error",
-        "name": "InsufficientDeposit",
-        "inputs": [
-            { "name": "amount", "type": "uint96", "internalType": "uint96" },
-            { "name": "minimumDeposit", "type": "uint96", "internalType": "uint96" }
-        ]
-    },
-    { "type": "error", "name": "InvalidInitialization", "inputs": [] },
-    {
-        "type": "error",
-        "name": "MigrationFailed",
-        "inputs": [
-            { "name": "migrator_", "type": "address", "internalType": "address" },
-            { "name": "revertData_", "type": "bytes", "internalType": "bytes" }
-        ]
-    },
-    { "type": "error", "name": "NoChange", "inputs": [] },
-    { "type": "error", "name": "NoExcess", "inputs": [] },
-    { "type": "error", "name": "NoPendingWithdrawal", "inputs": [] },
-    { "type": "error", "name": "NotInitializing", "inputs": [] },
-    { "type": "error", "name": "NotSettler", "inputs": [] },
-    { "type": "error", "name": "ParameterOutOfTypeBounds", "inputs": [] },
-    { "type": "error", "name": "Paused", "inputs": [] },
-    { "type": "error", "name": "PayerInDebt", "inputs": [] },
-    { "type": "error", "name": "PendingWithdrawalExists", "inputs": [] },
-    { "type": "error", "name": "TransferFromFailed", "inputs": [] },
-    {
-        "type": "error",
-        "name": "WithdrawalNotReady",
-        "inputs": [
-            { "name": "timestamp", "type": "uint32", "internalType": "uint32" },
-            { "name": "withdrawableTimestamp", "type": "uint32", "internalType": "uint32" }
-        ]
-    },
-    { "type": "error", "name": "ZeroFeeDistributor", "inputs": [] },
-    { "type": "error", "name": "ZeroFeeToken", "inputs": [] },
-    { "type": "error", "name": "ZeroMigrator", "inputs": [] },
-    { "type": "error", "name": "ZeroMinimumDeposit", "inputs": [] },
-    { "type": "error", "name": "ZeroParameterRegistry", "inputs": [] },
-    { "type": "error", "name": "ZeroPayer", "inputs": [] },
-    { "type": "error", "name": "ZeroRecipient", "inputs": [] },
-    { "type": "error", "name": "ZeroSettler", "inputs": [] },
-    { "type": "error", "name": "ZeroWithdrawalAmount", "inputs": [] }
+        "type": "uint32",
+        "indexed": false,
+        "internalType": "uint32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "WithdrawalCancelled",
+    "inputs": [
+      {
+        "name": "payer",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "WithdrawalFinalized",
+    "inputs": [
+      {
+        "name": "payer",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "WithdrawalRequested",
+    "inputs": [
+      {
+        "name": "payer",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint96",
+        "indexed": false,
+        "internalType": "uint96"
+      },
+      {
+        "name": "withdrawableTimestamp",
+        "type": "uint32",
+        "indexed": false,
+        "internalType": "uint32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "EmptyCode",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InsufficientBalance",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InsufficientDeposit",
+    "inputs": [
+      {
+        "name": "amount",
+        "type": "uint96",
+        "internalType": "uint96"
+      },
+      {
+        "name": "minimumDeposit",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InvalidInitialization",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MigrationFailed",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "revertData_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "NoChange",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NoExcess",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NoPendingWithdrawal",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotSettler",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ParameterOutOfTypeBounds",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Paused",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "PayerInDebt",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "PendingWithdrawalExists",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "TransferFromFailed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "WithdrawalNotReady",
+    "inputs": [
+      {
+        "name": "timestamp",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "withdrawableTimestamp",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ZeroFeeDistributor",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroFeeToken",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroMigrator",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroMinimumDeposit",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroParameterRegistry",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroPayer",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroRecipient",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroSettler",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroWithdrawalAmount",
+    "inputs": []
+  }
 ]

--- a/settlement-chain/abis/PayerReportManager.abi.json
+++ b/settlement-chain/abis/PayerReportManager.abi.json
@@ -1,314 +1,812 @@
 [
-    {
-        "type": "constructor",
-        "inputs": [
-            { "name": "parameterRegistry_", "type": "address", "internalType": "address" },
-            { "name": "nodeRegistry_", "type": "address", "internalType": "address" },
-            { "name": "payerRegistry_", "type": "address", "internalType": "address" }
-        ],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "DOMAIN_SEPARATOR",
-        "inputs": [],
-        "outputs": [{ "name": "domainSeparator_", "type": "bytes32", "internalType": "bytes32" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "ONE_HUNDRED_PERCENT",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "uint16", "internalType": "uint16" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "PAYER_REPORT_TYPEHASH",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "bytes32", "internalType": "bytes32" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "eip712Domain",
-        "inputs": [],
-        "outputs": [
-            { "name": "fields_", "type": "bytes1", "internalType": "bytes1" },
-            { "name": "name_", "type": "string", "internalType": "string" },
-            { "name": "version_", "type": "string", "internalType": "string" },
-            { "name": "chainId_", "type": "uint256", "internalType": "uint256" },
-            { "name": "verifyingContract_", "type": "address", "internalType": "address" },
-            { "name": "salt_", "type": "bytes32", "internalType": "bytes32" },
-            { "name": "extensions_", "type": "uint256[]", "internalType": "uint256[]" }
-        ],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "getPayerReport",
-        "inputs": [
-            { "name": "originatorNodeId_", "type": "uint32", "internalType": "uint32" },
-            { "name": "payerReportIndex_", "type": "uint256", "internalType": "uint256" }
-        ],
-        "outputs": [
-            {
-                "name": "payerReport_",
-                "type": "tuple",
-                "internalType": "struct IPayerReportManager.PayerReport",
-                "components": [
-                    { "name": "startSequenceId", "type": "uint64", "internalType": "uint64" },
-                    { "name": "endSequenceId", "type": "uint64", "internalType": "uint64" },
-                    { "name": "endMinuteSinceEpoch", "type": "uint32", "internalType": "uint32" },
-                    { "name": "feesSettled", "type": "uint96", "internalType": "uint96" },
-                    { "name": "offset", "type": "uint32", "internalType": "uint32" },
-                    { "name": "isSettled", "type": "bool", "internalType": "bool" },
-                    { "name": "protocolFeeRate", "type": "uint16", "internalType": "uint16" },
-                    { "name": "payersMerkleRoot", "type": "bytes32", "internalType": "bytes32" },
-                    { "name": "nodeIds", "type": "uint32[]", "internalType": "uint32[]" }
-                ]
-            }
-        ],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "getPayerReportDigest",
-        "inputs": [
-            { "name": "originatorNodeId_", "type": "uint32", "internalType": "uint32" },
-            { "name": "startSequenceId_", "type": "uint64", "internalType": "uint64" },
-            { "name": "endSequenceId_", "type": "uint64", "internalType": "uint64" },
-            { "name": "endMinuteSinceEpoch_", "type": "uint32", "internalType": "uint32" },
-            { "name": "payersMerkleRoot_", "type": "bytes32", "internalType": "bytes32" },
-            { "name": "nodeIds_", "type": "uint32[]", "internalType": "uint32[]" }
-        ],
-        "outputs": [{ "name": "digest_", "type": "bytes32", "internalType": "bytes32" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "getPayerReports",
-        "inputs": [
-            { "name": "originatorNodeIds_", "type": "uint32[]", "internalType": "uint32[]" },
-            { "name": "payerReportIndices_", "type": "uint256[]", "internalType": "uint256[]" }
-        ],
-        "outputs": [
-            {
-                "name": "payerReports_",
-                "type": "tuple[]",
-                "internalType": "struct IPayerReportManager.PayerReport[]",
-                "components": [
-                    { "name": "startSequenceId", "type": "uint64", "internalType": "uint64" },
-                    { "name": "endSequenceId", "type": "uint64", "internalType": "uint64" },
-                    { "name": "endMinuteSinceEpoch", "type": "uint32", "internalType": "uint32" },
-                    { "name": "feesSettled", "type": "uint96", "internalType": "uint96" },
-                    { "name": "offset", "type": "uint32", "internalType": "uint32" },
-                    { "name": "isSettled", "type": "bool", "internalType": "bool" },
-                    { "name": "protocolFeeRate", "type": "uint16", "internalType": "uint16" },
-                    { "name": "payersMerkleRoot", "type": "bytes32", "internalType": "bytes32" },
-                    { "name": "nodeIds", "type": "uint32[]", "internalType": "uint32[]" }
-                ]
-            }
-        ],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "implementation",
-        "inputs": [],
-        "outputs": [{ "name": "implementation_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    { "type": "function", "name": "initialize", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    { "type": "function", "name": "migrate", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "migratorParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "nodeRegistry",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "parameterRegistry",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "payerRegistry",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "parameterRegistry_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "nodeRegistry_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "payerRegistry_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "DOMAIN_SEPARATOR",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "domainSeparator_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "ONE_HUNDRED_PERCENT",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "PAYER_REPORT_TYPEHASH",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "eip712Domain",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "fields_",
+        "type": "bytes1",
+        "internalType": "bytes1"
+      },
+      {
+        "name": "name_",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "version_",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "chainId_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "verifyingContract_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "salt_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "extensions_",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getPayerReport",
+    "inputs": [
+      {
+        "name": "originatorNodeId_",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "payerReportIndex_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "payerReport_",
+        "type": "tuple",
+        "internalType": "struct IPayerReportManager.PayerReport",
+        "components": [
+          {
+            "name": "startSequenceId",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "endSequenceId",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "endMinuteSinceEpoch",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "feesSettled",
+            "type": "uint96",
+            "internalType": "uint96"
+          },
+          {
+            "name": "offset",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "isSettled",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "protocolFeeRate",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "payersMerkleRoot",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "nodeIds",
+            "type": "uint32[]",
+            "internalType": "uint32[]"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getPayerReportDigest",
+    "inputs": [
+      {
+        "name": "originatorNodeId_",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "startSequenceId_",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "endSequenceId_",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "endMinuteSinceEpoch_",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "payersMerkleRoot_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "nodeIds_",
+        "type": "uint32[]",
+        "internalType": "uint32[]"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "digest_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getPayerReports",
+    "inputs": [
+      {
+        "name": "originatorNodeIds_",
+        "type": "uint32[]",
+        "internalType": "uint32[]"
+      },
+      {
+        "name": "payerReportIndices_",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "payerReports_",
+        "type": "tuple[]",
+        "internalType": "struct IPayerReportManager.PayerReport[]",
+        "components": [
+          {
+            "name": "startSequenceId",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "endSequenceId",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "endMinuteSinceEpoch",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "feesSettled",
+            "type": "uint96",
+            "internalType": "uint96"
+          },
+          {
+            "name": "offset",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "isSettled",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "protocolFeeRate",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "payersMerkleRoot",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "nodeIds",
+            "type": "uint32[]",
+            "internalType": "uint32[]"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "implementation",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "implementation_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "migrate",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "migratorParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "nodeRegistry",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "parameterRegistry",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "payerRegistry",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "protocolFeeRate",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "protocolFeeRate_",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "protocolFeeRateParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "settle",
+    "inputs": [
+      {
+        "name": "originatorNodeId_",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "payerReportIndex_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "payerFees_",
+        "type": "bytes[]",
+        "internalType": "bytes[]"
+      },
+      {
+        "name": "proofElements_",
+        "type": "bytes32[]",
+        "internalType": "bytes32[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "submit",
+    "inputs": [
+      {
+        "name": "originatorNodeId_",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "startSequenceId_",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "endSequenceId_",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "endMinuteSinceEpoch_",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "payersMerkleRoot_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "nodeIds_",
+        "type": "uint32[]",
+        "internalType": "uint32[]"
+      },
+      {
+        "name": "signatures_",
+        "type": "tuple[]",
+        "internalType": "struct IPayerReportManager.PayerReportSignature[]",
+        "components": [
+          {
+            "name": "nodeId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "signature",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "payerReportIndex_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateProtocolFeeRate",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "EIP712DomainChanged",
+    "inputs": [],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Migrated",
+    "inputs": [
+      {
+        "name": "migrator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PayerReportSubmitted",
+    "inputs": [
+      {
+        "name": "originatorNodeId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "payerReportIndex",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "startSequenceId",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      },
+      {
+        "name": "endSequenceId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "endMinuteSinceEpoch",
+        "type": "uint32",
+        "indexed": false,
+        "internalType": "uint32"
+      },
+      {
+        "name": "payersMerkleRoot",
+        "type": "bytes32",
+        "indexed": false,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "nodeIds",
+        "type": "uint32[]",
+        "indexed": false,
+        "internalType": "uint32[]"
+      },
+      {
+        "name": "signingNodeIds",
+        "type": "uint32[]",
+        "indexed": false,
+        "internalType": "uint32[]"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PayerReportSubsetSettled",
+    "inputs": [
+      {
+        "name": "originatorNodeId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "payerReportIndex",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "count",
+        "type": "uint32",
+        "indexed": false,
+        "internalType": "uint32"
+      },
+      {
+        "name": "remaining",
+        "type": "uint32",
+        "indexed": false,
+        "internalType": "uint32"
+      },
+      {
+        "name": "feesSettled",
+        "type": "uint96",
+        "indexed": false,
+        "internalType": "uint96"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ProtocolFeeRateUpdated",
+    "inputs": [
+      {
         "name": "protocolFeeRate",
-        "inputs": [],
-        "outputs": [{ "name": "protocolFeeRate_", "type": "uint16", "internalType": "uint16" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "protocolFeeRateParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "settle",
-        "inputs": [
-            { "name": "originatorNodeId_", "type": "uint32", "internalType": "uint32" },
-            { "name": "payerReportIndex_", "type": "uint256", "internalType": "uint256" },
-            { "name": "payerFees_", "type": "bytes[]", "internalType": "bytes[]" },
-            { "name": "proofElements_", "type": "bytes32[]", "internalType": "bytes32[]" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "submit",
-        "inputs": [
-            { "name": "originatorNodeId_", "type": "uint32", "internalType": "uint32" },
-            { "name": "startSequenceId_", "type": "uint64", "internalType": "uint64" },
-            { "name": "endSequenceId_", "type": "uint64", "internalType": "uint64" },
-            { "name": "endMinuteSinceEpoch_", "type": "uint32", "internalType": "uint32" },
-            { "name": "payersMerkleRoot_", "type": "bytes32", "internalType": "bytes32" },
-            { "name": "nodeIds_", "type": "uint32[]", "internalType": "uint32[]" },
-            {
-                "name": "signatures_",
-                "type": "tuple[]",
-                "internalType": "struct IPayerReportManager.PayerReportSignature[]",
-                "components": [
-                    { "name": "nodeId", "type": "uint32", "internalType": "uint32" },
-                    { "name": "signature", "type": "bytes", "internalType": "bytes" }
-                ]
-            }
-        ],
-        "outputs": [{ "name": "payerReportIndex_", "type": "uint256", "internalType": "uint256" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "updateProtocolFeeRate",
-        "inputs": [],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    { "type": "event", "name": "EIP712DomainChanged", "inputs": [], "anonymous": false },
-    {
-        "type": "event",
-        "name": "Initialized",
-        "inputs": [{ "name": "version", "type": "uint64", "indexed": false, "internalType": "uint64" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Migrated",
-        "inputs": [{ "name": "migrator", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "PayerReportSubmitted",
-        "inputs": [
-            { "name": "originatorNodeId", "type": "uint32", "indexed": true, "internalType": "uint32" },
-            { "name": "payerReportIndex", "type": "uint256", "indexed": true, "internalType": "uint256" },
-            { "name": "startSequenceId", "type": "uint64", "indexed": false, "internalType": "uint64" },
-            { "name": "endSequenceId", "type": "uint64", "indexed": true, "internalType": "uint64" },
-            { "name": "endMinuteSinceEpoch", "type": "uint32", "indexed": false, "internalType": "uint32" },
-            { "name": "payersMerkleRoot", "type": "bytes32", "indexed": false, "internalType": "bytes32" },
-            { "name": "nodeIds", "type": "uint32[]", "indexed": false, "internalType": "uint32[]" },
-            { "name": "signingNodeIds", "type": "uint32[]", "indexed": false, "internalType": "uint32[]" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "PayerReportSubsetSettled",
-        "inputs": [
-            { "name": "originatorNodeId", "type": "uint32", "indexed": true, "internalType": "uint32" },
-            { "name": "payerReportIndex", "type": "uint256", "indexed": true, "internalType": "uint256" },
-            { "name": "count", "type": "uint32", "indexed": false, "internalType": "uint32" },
-            { "name": "remaining", "type": "uint32", "indexed": false, "internalType": "uint32" },
-            { "name": "feesSettled", "type": "uint96", "indexed": false, "internalType": "uint96" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "ProtocolFeeRateUpdated",
-        "inputs": [{ "name": "protocolFeeRate", "type": "uint16", "indexed": false, "internalType": "uint16" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Upgraded",
-        "inputs": [{ "name": "implementation", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    { "type": "error", "name": "ArrayLengthMismatch", "inputs": [] },
-    {
-        "type": "error",
-        "name": "EmptyCode",
-        "inputs": [{ "name": "migrator_", "type": "address", "internalType": "address" }]
-    },
-    {
-        "type": "error",
-        "name": "InsufficientSignatures",
-        "inputs": [
-            { "name": "validSignatureCount", "type": "uint8", "internalType": "uint8" },
-            { "name": "requiredSignatureCount", "type": "uint8", "internalType": "uint8" }
-        ]
-    },
-    { "type": "error", "name": "InvalidBitCount32Input", "inputs": [] },
-    { "type": "error", "name": "InvalidInitialization", "inputs": [] },
-    { "type": "error", "name": "InvalidLeafCount", "inputs": [] },
-    { "type": "error", "name": "InvalidProof", "inputs": [] },
-    { "type": "error", "name": "InvalidProtocolFeeRate", "inputs": [] },
-    { "type": "error", "name": "InvalidSequenceIds", "inputs": [] },
-    {
-        "type": "error",
-        "name": "InvalidStartSequenceId",
-        "inputs": [
-            { "name": "startSequenceId", "type": "uint64", "internalType": "uint64" },
-            { "name": "lastSequenceId", "type": "uint64", "internalType": "uint64" }
-        ]
-    },
-    {
-        "type": "error",
-        "name": "MigrationFailed",
-        "inputs": [
-            { "name": "migrator_", "type": "address", "internalType": "address" },
-            { "name": "revertData_", "type": "bytes", "internalType": "bytes" }
-        ]
-    },
-    { "type": "error", "name": "NoChange", "inputs": [] },
-    { "type": "error", "name": "NoLeaves", "inputs": [] },
-    { "type": "error", "name": "NoProofElements", "inputs": [] },
-    { "type": "error", "name": "NotInitializing", "inputs": [] },
-    { "type": "error", "name": "ParameterOutOfTypeBounds", "inputs": [] },
-    { "type": "error", "name": "PayerFeesLengthTooLong", "inputs": [] },
-    { "type": "error", "name": "PayerReportEntirelySettled", "inputs": [] },
-    { "type": "error", "name": "PayerReportIndexOutOfBounds", "inputs": [] },
-    {
-        "type": "error",
-        "name": "SettleUsageFailed",
-        "inputs": [{ "name": "returnData_", "type": "bytes", "internalType": "bytes" }]
-    },
-    { "type": "error", "name": "UnorderedNodeIds", "inputs": [] },
-    { "type": "error", "name": "ZeroMigrator", "inputs": [] },
-    { "type": "error", "name": "ZeroNodeRegistry", "inputs": [] },
-    { "type": "error", "name": "ZeroParameterRegistry", "inputs": [] },
-    { "type": "error", "name": "ZeroPayerRegistry", "inputs": [] }
+        "type": "uint16",
+        "indexed": false,
+        "internalType": "uint16"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "ArrayLengthMismatch",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "EmptyCode",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InsufficientSignatures",
+    "inputs": [
+      {
+        "name": "validSignatureCount",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "requiredSignatureCount",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InvalidBitCount32Input",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidInitialization",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidLeafCount",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidProof",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidProtocolFeeRate",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidSequenceIds",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidStartSequenceId",
+    "inputs": [
+      {
+        "name": "startSequenceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "lastSequenceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "MigrationFailed",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "revertData_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "NoChange",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NoLeaves",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NoProofElements",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ParameterOutOfTypeBounds",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "PayerFeesLengthTooLong",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "PayerReportEntirelySettled",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "PayerReportIndexOutOfBounds",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "SettleUsageFailed",
+    "inputs": [
+      {
+        "name": "returnData_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "UnorderedNodeIds",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroMigrator",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroNodeRegistry",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroParameterRegistry",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroPayerRegistry",
+    "inputs": []
+  }
 ]

--- a/settlement-chain/abis/RateRegistry.abi.json
+++ b/settlement-chain/abis/RateRegistry.abi.json
@@ -1,140 +1,331 @@
 [
-    {
-        "type": "constructor",
-        "inputs": [{ "name": "parameterRegistry_", "type": "address", "internalType": "address" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "congestionFeeParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "getRates",
-        "inputs": [
-            { "name": "fromIndex_", "type": "uint256", "internalType": "uint256" },
-            { "name": "count_", "type": "uint256", "internalType": "uint256" }
-        ],
-        "outputs": [
-            {
-                "name": "rates_",
-                "type": "tuple[]",
-                "internalType": "struct IRateRegistry.Rates[]",
-                "components": [
-                    { "name": "messageFee", "type": "uint64", "internalType": "uint64" },
-                    { "name": "storageFee", "type": "uint64", "internalType": "uint64" },
-                    { "name": "congestionFee", "type": "uint64", "internalType": "uint64" },
-                    { "name": "targetRatePerMinute", "type": "uint64", "internalType": "uint64" },
-                    { "name": "startTime", "type": "uint64", "internalType": "uint64" }
-                ]
-            }
-        ],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "getRatesCount",
-        "inputs": [],
-        "outputs": [{ "name": "count_", "type": "uint256", "internalType": "uint256" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "implementation",
-        "inputs": [],
-        "outputs": [{ "name": "implementation_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    { "type": "function", "name": "initialize", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "messageFeeParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    { "type": "function", "name": "migrate", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "migratorParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "parameterRegistry",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "storageFeeParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "targetRatePerMinuteParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    { "type": "function", "name": "updateRates", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "event",
-        "name": "Initialized",
-        "inputs": [{ "name": "version", "type": "uint64", "indexed": false, "internalType": "uint64" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Migrated",
-        "inputs": [{ "name": "migrator", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "RatesUpdated",
-        "inputs": [
-            { "name": "messageFee", "type": "uint64", "indexed": false, "internalType": "uint64" },
-            { "name": "storageFee", "type": "uint64", "indexed": false, "internalType": "uint64" },
-            { "name": "congestionFee", "type": "uint64", "indexed": false, "internalType": "uint64" },
-            { "name": "targetRatePerMinute", "type": "uint64", "indexed": false, "internalType": "uint64" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Upgraded",
-        "inputs": [{ "name": "implementation", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "error",
-        "name": "EmptyCode",
-        "inputs": [{ "name": "migrator_", "type": "address", "internalType": "address" }]
-    },
-    { "type": "error", "name": "EndIndexOutOfRange", "inputs": [] },
-    { "type": "error", "name": "FromIndexOutOfRange", "inputs": [] },
-    { "type": "error", "name": "InvalidInitialization", "inputs": [] },
-    {
-        "type": "error",
-        "name": "MigrationFailed",
-        "inputs": [
-            { "name": "migrator_", "type": "address", "internalType": "address" },
-            { "name": "revertData_", "type": "bytes", "internalType": "bytes" }
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "parameterRegistry_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "congestionFeeParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "getRates",
+    "inputs": [
+      {
+        "name": "fromIndex_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "count_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "rates_",
+        "type": "tuple[]",
+        "internalType": "struct IRateRegistry.Rates[]",
+        "components": [
+          {
+            "name": "messageFee",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "storageFee",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "congestionFee",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "targetRatePerMinute",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "startTime",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
         ]
-    },
-    { "type": "error", "name": "NoChange", "inputs": [] },
-    { "type": "error", "name": "NotInitializing", "inputs": [] },
-    { "type": "error", "name": "ParameterOutOfTypeBounds", "inputs": [] },
-    { "type": "error", "name": "ZeroCount", "inputs": [] },
-    { "type": "error", "name": "ZeroMigrator", "inputs": [] },
-    { "type": "error", "name": "ZeroParameterRegistry", "inputs": [] }
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getRatesCount",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "count_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "implementation",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "implementation_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "messageFeeParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "migrate",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "migratorParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "parameterRegistry",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "storageFeeParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "targetRatePerMinuteParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "updateRates",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Migrated",
+    "inputs": [
+      {
+        "name": "migrator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RatesUpdated",
+    "inputs": [
+      {
+        "name": "messageFee",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      },
+      {
+        "name": "storageFee",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      },
+      {
+        "name": "congestionFee",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      },
+      {
+        "name": "targetRatePerMinute",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "EmptyCode",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "EndIndexOutOfRange",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "FromIndexOutOfRange",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidInitialization",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MigrationFailed",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "revertData_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "NoChange",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ParameterOutOfTypeBounds",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroCount",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroMigrator",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroParameterRegistry",
+    "inputs": []
+  }
 ]

--- a/settlement-chain/abis/SettlementChainGateway.abi.json
+++ b/settlement-chain/abis/SettlementChainGateway.abi.json
@@ -1,342 +1,913 @@
 [
-    {
-        "type": "constructor",
-        "inputs": [
-            { "name": "parameterRegistry_", "type": "address", "internalType": "address" },
-            { "name": "appChainGateway_", "type": "address", "internalType": "address" },
-            { "name": "feeToken_", "type": "address", "internalType": "address" }
-        ],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "appChainAlias",
-        "inputs": [],
-        "outputs": [{ "name": "alias_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "appChainGateway",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "calculateMaxDepositFee",
-        "inputs": [
-            { "name": "chainId_", "type": "uint256", "internalType": "uint256" },
-            { "name": "gasLimit_", "type": "uint256", "internalType": "uint256" },
-            { "name": "maxFeePerGas_", "type": "uint256", "internalType": "uint256" },
-            { "name": "maxBaseFee_", "type": "uint256", "internalType": "uint256" }
-        ],
-        "outputs": [{ "name": "fees_", "type": "uint256", "internalType": "uint256" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "deposit",
-        "inputs": [
-            { "name": "chainId_", "type": "uint256", "internalType": "uint256" },
-            { "name": "recipient_", "type": "address", "internalType": "address" },
-            { "name": "amount_", "type": "uint256", "internalType": "uint256" },
-            { "name": "gasLimit_", "type": "uint256", "internalType": "uint256" },
-            { "name": "maxFeePerGas_", "type": "uint256", "internalType": "uint256" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "depositFromUnderlying",
-        "inputs": [
-            { "name": "chainId_", "type": "uint256", "internalType": "uint256" },
-            { "name": "recipient_", "type": "address", "internalType": "address" },
-            { "name": "amount_", "type": "uint256", "internalType": "uint256" },
-            { "name": "gasLimit_", "type": "uint256", "internalType": "uint256" },
-            { "name": "maxFeePerGas_", "type": "uint256", "internalType": "uint256" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "depositFromUnderlyingWithPermit",
-        "inputs": [
-            { "name": "chainId_", "type": "uint256", "internalType": "uint256" },
-            { "name": "recipient_", "type": "address", "internalType": "address" },
-            { "name": "amount_", "type": "uint256", "internalType": "uint256" },
-            { "name": "gasLimit_", "type": "uint256", "internalType": "uint256" },
-            { "name": "maxFeePerGas_", "type": "uint256", "internalType": "uint256" },
-            { "name": "deadline_", "type": "uint256", "internalType": "uint256" },
-            { "name": "v_", "type": "uint8", "internalType": "uint8" },
-            { "name": "r_", "type": "bytes32", "internalType": "bytes32" },
-            { "name": "s_", "type": "bytes32", "internalType": "bytes32" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "depositWithPermit",
-        "inputs": [
-            { "name": "chainId_", "type": "uint256", "internalType": "uint256" },
-            { "name": "recipient_", "type": "address", "internalType": "address" },
-            { "name": "amount_", "type": "uint256", "internalType": "uint256" },
-            { "name": "gasLimit_", "type": "uint256", "internalType": "uint256" },
-            { "name": "maxFeePerGas_", "type": "uint256", "internalType": "uint256" },
-            { "name": "deadline_", "type": "uint256", "internalType": "uint256" },
-            { "name": "v_", "type": "uint8", "internalType": "uint8" },
-            { "name": "r_", "type": "bytes32", "internalType": "bytes32" },
-            { "name": "s_", "type": "bytes32", "internalType": "bytes32" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "feeToken",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "getInbox",
-        "inputs": [{ "name": "chainId_", "type": "uint256", "internalType": "uint256" }],
-        "outputs": [{ "name": "inbox_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "implementation",
-        "inputs": [],
-        "outputs": [{ "name": "implementation_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "inboxParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    { "type": "function", "name": "initialize", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    { "type": "function", "name": "migrate", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "migratorParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "parameterRegistry",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "parameterRegistry_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "appChainGateway_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "feeToken_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "appChainAlias",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "alias_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "appChainGateway",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "calculateMaxDepositFee",
+    "inputs": [
+      {
+        "name": "chainId_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "gasLimit_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "maxFeePerGas_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "maxBaseFee_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "fees_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "deposit",
+    "inputs": [
+      {
+        "name": "chainId_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "recipient_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "gasLimit_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "maxFeePerGas_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "depositFromUnderlying",
+    "inputs": [
+      {
+        "name": "chainId_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "recipient_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "gasLimit_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "maxFeePerGas_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "depositFromUnderlyingWithPermit",
+    "inputs": [
+      {
+        "name": "chainId_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "recipient_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "gasLimit_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "maxFeePerGas_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "deadline_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "v_",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "r_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "s_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "depositWithPermit",
+    "inputs": [
+      {
+        "name": "chainId_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "recipient_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "gasLimit_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "maxFeePerGas_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "deadline_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "v_",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "r_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "s_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "feeToken",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getInbox",
+    "inputs": [
+      {
+        "name": "chainId_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "inbox_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "implementation",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "implementation_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "inboxParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "migrate",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "migratorParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "parameterRegistry",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "paused",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "paused_",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "pausedParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "receiveWithdrawal",
+    "inputs": [
+      {
+        "name": "recipient_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "amount_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "receiveWithdrawalIntoUnderlying",
+    "inputs": [
+      {
+        "name": "recipient_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "amount_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "sendParameters",
+    "inputs": [
+      {
+        "name": "chainIds_",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      },
+      {
+        "name": "keys_",
+        "type": "string[]",
+        "internalType": "string[]"
+      },
+      {
+        "name": "gasLimit_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "maxFeePerGas_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "amountToSend_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "totalSent_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "sendParametersFromUnderlying",
+    "inputs": [
+      {
+        "name": "chainIds_",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      },
+      {
+        "name": "keys_",
+        "type": "string[]",
+        "internalType": "string[]"
+      },
+      {
+        "name": "gasLimit_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "maxFeePerGas_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "amountToSend_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "totalSent_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "sendParametersFromUnderlyingWithPermit",
+    "inputs": [
+      {
+        "name": "chainIds_",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      },
+      {
+        "name": "keys_",
+        "type": "string[]",
+        "internalType": "string[]"
+      },
+      {
+        "name": "gasLimit_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "maxFeePerGas_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "amountToSend_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "deadline_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "v_",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "r_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "s_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "totalSent_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "sendParametersWithPermit",
+    "inputs": [
+      {
+        "name": "chainIds_",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      },
+      {
+        "name": "keys_",
+        "type": "string[]",
+        "internalType": "string[]"
+      },
+      {
+        "name": "gasLimit_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "maxFeePerGas_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "amountToSend_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "deadline_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "v_",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "r_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "s_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "totalSent_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateInbox",
+    "inputs": [
+      {
+        "name": "chainId_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updatePauseStatus",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "Deposit",
+    "inputs": [
+      {
+        "name": "chainId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "messageNumber",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "InboxUpdated",
+    "inputs": [
+      {
+        "name": "chainId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "inbox",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Migrated",
+    "inputs": [
+      {
+        "name": "migrator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ParametersSent",
+    "inputs": [
+      {
+        "name": "chainId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "messageNumber",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "nonce",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "keys",
+        "type": "string[]",
+        "indexed": false,
+        "internalType": "string[]"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PauseStatusUpdated",
+    "inputs": [
+      {
         "name": "paused",
-        "inputs": [],
-        "outputs": [{ "name": "paused_", "type": "bool", "internalType": "bool" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "pausedParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "receiveWithdrawal",
-        "inputs": [{ "name": "recipient_", "type": "address", "internalType": "address" }],
-        "outputs": [{ "name": "amount_", "type": "uint256", "internalType": "uint256" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "receiveWithdrawalIntoUnderlying",
-        "inputs": [{ "name": "recipient_", "type": "address", "internalType": "address" }],
-        "outputs": [{ "name": "amount_", "type": "uint256", "internalType": "uint256" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "sendParameters",
-        "inputs": [
-            { "name": "chainIds_", "type": "uint256[]", "internalType": "uint256[]" },
-            { "name": "keys_", "type": "string[]", "internalType": "string[]" },
-            { "name": "gasLimit_", "type": "uint256", "internalType": "uint256" },
-            { "name": "maxFeePerGas_", "type": "uint256", "internalType": "uint256" },
-            { "name": "amountToSend_", "type": "uint256", "internalType": "uint256" }
-        ],
-        "outputs": [{ "name": "totalSent_", "type": "uint256", "internalType": "uint256" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "sendParametersFromUnderlying",
-        "inputs": [
-            { "name": "chainIds_", "type": "uint256[]", "internalType": "uint256[]" },
-            { "name": "keys_", "type": "string[]", "internalType": "string[]" },
-            { "name": "gasLimit_", "type": "uint256", "internalType": "uint256" },
-            { "name": "maxFeePerGas_", "type": "uint256", "internalType": "uint256" },
-            { "name": "amountToSend_", "type": "uint256", "internalType": "uint256" }
-        ],
-        "outputs": [{ "name": "totalSent_", "type": "uint256", "internalType": "uint256" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "sendParametersFromUnderlyingWithPermit",
-        "inputs": [
-            { "name": "chainIds_", "type": "uint256[]", "internalType": "uint256[]" },
-            { "name": "keys_", "type": "string[]", "internalType": "string[]" },
-            { "name": "gasLimit_", "type": "uint256", "internalType": "uint256" },
-            { "name": "maxFeePerGas_", "type": "uint256", "internalType": "uint256" },
-            { "name": "amountToSend_", "type": "uint256", "internalType": "uint256" },
-            { "name": "deadline_", "type": "uint256", "internalType": "uint256" },
-            { "name": "v_", "type": "uint8", "internalType": "uint8" },
-            { "name": "r_", "type": "bytes32", "internalType": "bytes32" },
-            { "name": "s_", "type": "bytes32", "internalType": "bytes32" }
-        ],
-        "outputs": [{ "name": "totalSent_", "type": "uint256", "internalType": "uint256" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "sendParametersWithPermit",
-        "inputs": [
-            { "name": "chainIds_", "type": "uint256[]", "internalType": "uint256[]" },
-            { "name": "keys_", "type": "string[]", "internalType": "string[]" },
-            { "name": "gasLimit_", "type": "uint256", "internalType": "uint256" },
-            { "name": "maxFeePerGas_", "type": "uint256", "internalType": "uint256" },
-            { "name": "amountToSend_", "type": "uint256", "internalType": "uint256" },
-            { "name": "deadline_", "type": "uint256", "internalType": "uint256" },
-            { "name": "v_", "type": "uint8", "internalType": "uint8" },
-            { "name": "r_", "type": "bytes32", "internalType": "bytes32" },
-            { "name": "s_", "type": "bytes32", "internalType": "bytes32" }
-        ],
-        "outputs": [{ "name": "totalSent_", "type": "uint256", "internalType": "uint256" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "updateInbox",
-        "inputs": [{ "name": "chainId_", "type": "uint256", "internalType": "uint256" }],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    { "type": "function", "name": "updatePauseStatus", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "event",
-        "name": "Deposit",
-        "inputs": [
-            { "name": "chainId", "type": "uint256", "indexed": true, "internalType": "uint256" },
-            { "name": "messageNumber", "type": "uint256", "indexed": true, "internalType": "uint256" },
-            { "name": "amount", "type": "uint256", "indexed": false, "internalType": "uint256" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "InboxUpdated",
-        "inputs": [
-            { "name": "chainId", "type": "uint256", "indexed": true, "internalType": "uint256" },
-            { "name": "inbox", "type": "address", "indexed": true, "internalType": "address" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Initialized",
-        "inputs": [{ "name": "version", "type": "uint64", "indexed": false, "internalType": "uint64" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Migrated",
-        "inputs": [{ "name": "migrator", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "ParametersSent",
-        "inputs": [
-            { "name": "chainId", "type": "uint256", "indexed": true, "internalType": "uint256" },
-            { "name": "messageNumber", "type": "uint256", "indexed": true, "internalType": "uint256" },
-            { "name": "nonce", "type": "uint256", "indexed": false, "internalType": "uint256" },
-            { "name": "keys", "type": "string[]", "indexed": false, "internalType": "string[]" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "PauseStatusUpdated",
-        "inputs": [{ "name": "paused", "type": "bool", "indexed": true, "internalType": "bool" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Upgraded",
-        "inputs": [{ "name": "implementation", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "WithdrawalReceived",
-        "inputs": [
-            { "name": "recipient", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "amount", "type": "uint256", "indexed": false, "internalType": "uint256" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "error",
-        "name": "EmptyCode",
-        "inputs": [{ "name": "migrator_", "type": "address", "internalType": "address" }]
-    },
-    {
-        "type": "error",
-        "name": "InsufficientAmount",
-        "inputs": [
-            { "name": "appChainAmount", "type": "uint256", "internalType": "uint256" },
-            { "name": "maxTotalCosts", "type": "uint256", "internalType": "uint256" }
-        ]
-    },
-    { "type": "error", "name": "InvalidFeeTokenDecimals", "inputs": [] },
-    { "type": "error", "name": "InvalidInitialization", "inputs": [] },
-    {
-        "type": "error",
-        "name": "MigrationFailed",
-        "inputs": [
-            { "name": "migrator_", "type": "address", "internalType": "address" },
-            { "name": "revertData_", "type": "bytes", "internalType": "bytes" }
-        ]
-    },
-    { "type": "error", "name": "NoChainIds", "inputs": [] },
-    { "type": "error", "name": "NoChange", "inputs": [] },
-    { "type": "error", "name": "NoKeys", "inputs": [] },
-    { "type": "error", "name": "NotInitializing", "inputs": [] },
-    { "type": "error", "name": "ParameterOutOfTypeBounds", "inputs": [] },
-    { "type": "error", "name": "Paused", "inputs": [] },
-    { "type": "error", "name": "TransferFromFailed", "inputs": [] },
-    {
-        "type": "error",
-        "name": "UnsupportedChainId",
-        "inputs": [{ "name": "chainId", "type": "uint256", "internalType": "uint256" }]
-    },
-    { "type": "error", "name": "ZeroAmount", "inputs": [] },
-    { "type": "error", "name": "ZeroAppChainGateway", "inputs": [] },
-    { "type": "error", "name": "ZeroBalance", "inputs": [] },
-    { "type": "error", "name": "ZeroFeeToken", "inputs": [] },
-    { "type": "error", "name": "ZeroMigrator", "inputs": [] },
-    { "type": "error", "name": "ZeroParameterRegistry", "inputs": [] },
-    { "type": "error", "name": "ZeroRecipient", "inputs": [] }
+        "type": "bool",
+        "indexed": true,
+        "internalType": "bool"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "WithdrawalReceived",
+    "inputs": [
+      {
+        "name": "recipient",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "EmptyCode",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InsufficientAmount",
+    "inputs": [
+      {
+        "name": "appChainAmount",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "maxTotalCosts",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InvalidFeeTokenDecimals",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidInitialization",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MigrationFailed",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "revertData_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "NoChainIds",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NoChange",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NoKeys",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ParameterOutOfTypeBounds",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Paused",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "TransferFromFailed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "UnsupportedChainId",
+    "inputs": [
+      {
+        "name": "chainId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ZeroAmount",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroAppChainGateway",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroBalance",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroFeeToken",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroMigrator",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroParameterRegistry",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroRecipient",
+    "inputs": []
+  }
 ]

--- a/settlement-chain/abis/SettlementChainParameterRegistry.abi.json
+++ b/settlement-chain/abis/SettlementChainParameterRegistry.abi.json
@@ -1,130 +1,305 @@
 [
-    {
-        "type": "function",
-        "name": "adminParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "get",
-        "inputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "outputs": [{ "name": "value_", "type": "bytes32", "internalType": "bytes32" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "get",
-        "inputs": [{ "name": "keys_", "type": "string[]", "internalType": "string[]" }],
-        "outputs": [{ "name": "values_", "type": "bytes32[]", "internalType": "bytes32[]" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
+  {
+    "type": "function",
+    "name": "adminParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "get",
+    "inputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "value_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "get",
+    "inputs": [
+      {
+        "name": "keys_",
+        "type": "string[]",
+        "internalType": "string[]"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "values_",
+        "type": "bytes32[]",
+        "internalType": "bytes32[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "implementation",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "implementation_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [
+      {
+        "name": "admins_",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "isAdmin",
+    "inputs": [
+      {
+        "name": "account_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "isAdmin_",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "migrate",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "migratorParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "set",
+    "inputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "value_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "set",
+    "inputs": [
+      {
+        "name": "keys_",
+        "type": "string[]",
+        "internalType": "string[]"
+      },
+      {
+        "name": "values_",
+        "type": "bytes32[]",
+        "internalType": "bytes32[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Migrated",
+    "inputs": [
+      {
+        "name": "migrator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ParameterSet",
+    "inputs": [
+      {
+        "name": "key",
+        "type": "string",
+        "indexed": true,
+        "internalType": "string"
+      },
+      {
+        "name": "value",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
         "name": "implementation",
-        "inputs": [],
-        "outputs": [{ "name": "implementation_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "initialize",
-        "inputs": [{ "name": "admins_", "type": "address[]", "internalType": "address[]" }],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "isAdmin",
-        "inputs": [{ "name": "account_", "type": "address", "internalType": "address" }],
-        "outputs": [{ "name": "isAdmin_", "type": "bool", "internalType": "bool" }],
-        "stateMutability": "view"
-    },
-    { "type": "function", "name": "migrate", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "migratorParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "set",
-        "inputs": [
-            { "name": "key_", "type": "string", "internalType": "string" },
-            { "name": "value_", "type": "bytes32", "internalType": "bytes32" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "set",
-        "inputs": [
-            { "name": "keys_", "type": "string[]", "internalType": "string[]" },
-            { "name": "values_", "type": "bytes32[]", "internalType": "bytes32[]" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "event",
-        "name": "Initialized",
-        "inputs": [{ "name": "version", "type": "uint64", "indexed": false, "internalType": "uint64" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Migrated",
-        "inputs": [{ "name": "migrator", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "ParameterSet",
-        "inputs": [
-            { "name": "key", "type": "string", "indexed": true, "internalType": "string" },
-            { "name": "value", "type": "bytes32", "indexed": true, "internalType": "bytes32" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Upgraded",
-        "inputs": [{ "name": "implementation", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    { "type": "error", "name": "ArrayLengthMismatch", "inputs": [] },
-    { "type": "error", "name": "EmptyAdmins", "inputs": [] },
-    {
-        "type": "error",
-        "name": "EmptyCode",
-        "inputs": [{ "name": "migrator_", "type": "address", "internalType": "address" }]
-    },
-    { "type": "error", "name": "InvalidInitialization", "inputs": [] },
-    {
-        "type": "error",
-        "name": "MigrationFailed",
-        "inputs": [
-            { "name": "migrator_", "type": "address", "internalType": "address" },
-            { "name": "revertData_", "type": "bytes", "internalType": "bytes" }
-        ]
-    },
-    { "type": "error", "name": "NoKeyComponents", "inputs": [] },
-    { "type": "error", "name": "NoKeys", "inputs": [] },
-    { "type": "error", "name": "NotAdmin", "inputs": [] },
-    { "type": "error", "name": "NotInitializing", "inputs": [] },
-    { "type": "error", "name": "ParameterOutOfTypeBounds", "inputs": [] },
-    {
-        "type": "error",
-        "name": "StringsInsufficientHexLength",
-        "inputs": [
-            { "name": "value", "type": "uint256", "internalType": "uint256" },
-            { "name": "length", "type": "uint256", "internalType": "uint256" }
-        ]
-    },
-    { "type": "error", "name": "ZeroAdmin", "inputs": [] },
-    { "type": "error", "name": "ZeroMigrator", "inputs": [] }
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "ArrayLengthMismatch",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "EmptyAdmins",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "EmptyCode",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InvalidInitialization",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MigrationFailed",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "revertData_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "NoKeyComponents",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NoKeys",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotAdmin",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ParameterOutOfTypeBounds",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "StringsInsufficientHexLength",
+    "inputs": [
+      {
+        "name": "value",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "length",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ZeroAdmin",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroMigrator",
+    "inputs": []
+  }
 ]

--- a/settlement-chain/testnet-staging.yaml
+++ b/settlement-chain/testnet-staging.yaml
@@ -113,7 +113,7 @@ dataSources:
       network: base-sepolia
       source:
           abi: PayerReportManager
-          address: '0x8644DB92F11fDeCBCBfB5F2Bb84a000f28F7B59c'
+          address: '0x868132030B97457582630456ACBe6bD303F17263'
           startBlock: 29155490
       mapping:
           kind: ethereum/events

--- a/settlement-chain/testnet.yaml
+++ b/settlement-chain/testnet.yaml
@@ -113,7 +113,7 @@ dataSources:
       network: base-sepolia
       source:
           abi: PayerReportManager
-          address: '0x9EC340209b54C661ceFF468B70fF8122ff9D009e'
+          address: '0x9de0b8C883c01F28A0F3d39De90c098F0941176f'
           startBlock: 29322114
       mapping:
           kind: ethereum/events
@@ -133,3 +133,43 @@ dataSources:
               - event: PayerReportSubsetSettled(indexed uint32,indexed uint256,uint32,uint32,uint96)
                 handler: handlePayerReportSubsetSettled
           file: ./src/payer-report-manager.ts
+    - kind: ethereum
+      name: SettlementChainGateway
+      network: base-sepolia
+      source:
+          abi: SettlementChainGateway
+          address: '0xB64D5bF62F30512Bd130C0D7c80DB7ac1e6801a3'
+          startBlock: 29322114
+      context:
+          startingImplementation:
+              type: String
+              data: '0xB64D5bF62F30512Bd130C0D7c80DB7ac1e6801a3'
+      mapping:
+          kind: ethereum/events
+          apiVersion: 0.0.9
+          language: wasm/assemblyscript
+          entities:
+              - History
+              - Account
+              - GatewayDeposit
+              - GatewayReceivedWithdrawal
+              - GatewayInbox
+              - ParameterSend
+              - SettlementChainGateway
+          abis:
+              - name: SettlementChainGateway
+                file: ./abis/SettlementChainGateway.abi.json
+          eventHandlers:
+              - event: Deposit(indexed uint256,indexed uint256,uint256)
+                handler: handleDeposit
+              - event: InboxUpdated(indexed uint256,indexed address)
+                handler: handleInboxUpdated
+              - event: ParametersSent(indexed uint256,indexed uint256,uint256,string[])
+                handler: handleParametersSent
+              - event: PauseStatusUpdated(indexed bool)
+                handler: handlePauseStatusUpdated
+              - event: WithdrawalReceived(indexed address,uint256)
+                handler: handleWithdrawalReceived
+              - event: Upgraded(indexed address)
+                handler: handleUpgraded
+          file: ./src/settlement-chain-gateway.ts


### PR DESCRIPTION
Updated ABIs from release https://github.com/xmtp/smart-contracts/releases/tag/v2025.12.12-1

  Deployments

  Settlement-Chain

  - testnet-staging: Deployed v0.2.7 with stable tag
    - API: https://api.goldsky.com/api/public/project_cmh3prjsr002wr4p22cdshlhh/subgraphs/settlement-chain-testnet-staging/stable/gn
  - testnet: Deployed v0.2.7 with stable tag
    - API: https://api.goldsky.com/api/public/project_cmh3prjsr002wr4p22cdshlhh/subgraphs/settlement-chain-testnet/stable/gn

  App-Chain

  - testnet-staging: Using existing v0.2.4 with stable tag (no changes needed)
    - API: https://api.goldsky.com/api/public/project_cmh3prjsr002wr4p22cdshlhh/subgraphs/app-chain-testnet-staging/stable/gn
  - testnet: Using existing v0.2.4 with stable tag (no changes needed)
    - API: https://api.goldsky.com/api/public/project_cmh3prjsr002wr4p22cdshlhh/subgraphs/app-chain-testnet/stable/gn
