### PR TITLE
Fix payer reports

### DIFF
--- a/settlement-chain/abis/PayerRegistry.abi.json
+++ b/settlement-chain/abis/PayerRegistry.abi.json
@@ -690,6 +690,12 @@
     "name": "UsageSettled",
     "inputs": [
       {
+        "name": "payerReportId",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
         "name": "payer",
         "type": "address",
         "indexed": true,

--- a/settlement-chain/testnet-staging.yaml
+++ b/settlement-chain/testnet-staging.yaml
@@ -8,7 +8,7 @@ dataSources:
       source:
           abi: PayerRegistry
           address: '0x208E94fbC9833B58765fedC30CFF8539C6356e88'
-          startBlock: 26900619
+          startBlock: 29155490
       context:
           startingImplementation:
               type: String
@@ -67,7 +67,7 @@ dataSources:
                 handler: handlePauseStatusUpdated
               - event: SettlerUpdated(indexed address)
                 handler: handleSettlerUpdated
-              - event: UsageSettled(indexed address,uint96)
+              - event: UsageSettled(indexed bytes32,indexed address,uint96)
                 handler: handleUsageSettled
               - event: WithdrawLockPeriodUpdated(uint32)
                 handler: handleWithdrawLockPeriodUpdated
@@ -84,8 +84,8 @@ dataSources:
       source:
           abi: FeeToken
           address: '0x63C6667798fdA65E2E29228C43fbfDa0Cd4634A8'
-          startBlock: 26900619
-          endBlock: 26900619 # Remove this when this is FeeToken/xUSD.
+          startBlock: 29155490
+          endBlock: 29155490 # Remove this when this is FeeToken/xUSD.
       context:
           payerRegistry:
               type: String

--- a/settlement-chain/testnet.yaml
+++ b/settlement-chain/testnet.yaml
@@ -8,7 +8,7 @@ dataSources:
       source:
           abi: PayerRegistry
           address: '0xF0bd6Ac8AA00BA083cF95C5438B33488cbd2562B'
-          startBlock: 26900619
+          startBlock: 29322100
       context:
           startingImplementation:
               type: String
@@ -67,7 +67,7 @@ dataSources:
                 handler: handlePauseStatusUpdated
               - event: SettlerUpdated(indexed address)
                 handler: handleSettlerUpdated
-              - event: UsageSettled(indexed address,uint96)
+              - event: UsageSettled(indexed bytes32,indexed address,uint96)
                 handler: handleUsageSettled
               - event: WithdrawLockPeriodUpdated(uint32)
                 handler: handleWithdrawLockPeriodUpdated
@@ -84,8 +84,8 @@ dataSources:
       source:
           abi: FeeToken
           address: '0x63C6667798fdA65E2E29228C43fbfDa0Cd4634A8'
-          startBlock: 26900619
-          endBlock: 26900619 # Remove this when this is FeeToken/xUSD.
+          startBlock: 29322100
+          endBlock: 29322100 # Remove this when this is FeeToken/xUSD.
       context:
           payerRegistry:
               type: String


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Add `payerReportId` to `PayerRegistry` UsageSettled event and update subgraph manifests to index from block 29155490 (staging) and 29322100 (testnet) to fix payer reports
Update the `PayerRegistry` ABI to include an indexed `bytes32 payerReportId` in the affected event and adjust subgraph manifests to consume `UsageSettled(indexed bytes32,indexed address,uint96)` with new start blocks for staging and testnet.

#### 📍Where to Start
Start with the ABI change in [PayerRegistry.abi.json](https://github.com/xmtp/subgraphs/pull/15/files#diff-97407de4581f5bf8f0fd6c5265c19536773134d1a50a506b6796a0b5891c1780), then review the event signature and block ranges in [testnet-staging.yaml](https://github.com/xmtp/subgraphs/pull/15/files#diff-0caa5679f2daf0fb81c66d911c59148c8e9e7fc121b4cea63873d5dc824487d5) and [testnet.yaml](https://github.com/xmtp/subgraphs/pull/15/files#diff-df843975ba8c4db8c1c0ad029e09568d88e92f0e8c7d5563e7f791cc52f4406d).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized a7190ee.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->