### PR TITLE
Fix payer reports

### DIFF
--- a/app-chain/schema.graphql
+++ b/app-chain/schema.graphql
@@ -35,6 +35,69 @@ interface BooleanSnapshotEntity implements SnapshotEntity {
     value: Boolean!
 }
 
+# ============ Daily Time Series - Interface ============ #
+
+interface DailyTimeSeriesEntity {
+    id: ID! @unique
+    date: String! @index          # YYYY-MM-DD format
+    dateTimestamp: Timestamp! @index  # Midnight UTC timestamp
+}
+
+# ============ Account - Daily Time Series ============ #
+
+type DailyAccountUsage implements DailyTimeSeriesEntity @entity(immutable: false) {
+    id: ID! @unique                      # Format: DailyAccountUsage-{accountAddress}-{YYYY-MM-DD}
+    date: String! @index                 # YYYY-MM-DD
+    dateTimestamp: Timestamp! @index     # Midnight UTC timestamp
+    account: Account! @index
+
+    # Daily deltas for group messages (NOT cumulative)
+    groupMessagesSent: BigInt!           # Messages sent this day
+    groupMessageBytesSent: BigInt!       # Bytes sent this day
+    groupMessageFees: BigInt!            # Gas fees for messages this day
+
+    # Daily deltas for identity updates (NOT cumulative)
+    identityUpdatesCreated: BigInt!      # Identity updates this day
+    identityUpdateBytesCreated: BigInt!  # Identity update bytes this day
+    identityUpdateFees: BigInt!          # Gas fees for identity updates this day
+
+    # Daily deltas for cross-chain operations
+    depositsReceived: BigInt!            # Deposits received this day
+
+    # Aggregated daily fees
+    totalFees: BigInt!                   # Total gas fees this day
+
+    # Metadata
+    eventCount: Int!                     # Number of events this day
+    lastUpdatedBlock: BigInt!            # Last block that updated this entity
+}
+
+# ============ Global - Daily Time Series ============ #
+
+type DailyGlobalUsage implements DailyTimeSeriesEntity @entity(immutable: false) {
+    id: ID! @unique                      # Format: DailyGlobalUsage-{YYYY-MM-DD}
+    date: String! @index                 # YYYY-MM-DD
+    dateTimestamp: Timestamp! @index     # Midnight UTC timestamp
+
+    # Daily deltas for group messages (NOT cumulative)
+    totalGroupMessagesSent: BigInt!
+    totalGroupMessageBytesSent: BigInt!
+    totalGroupMessageFees: BigInt!
+
+    # Daily deltas for identity updates (NOT cumulative)
+    totalIdentityUpdatesCreated: BigInt!
+    totalIdentityUpdateBytesCreated: BigInt!
+    totalIdentityUpdateFees: BigInt!
+
+    # Daily deltas for cross-chain operations
+    totalDepositsReceived: BigInt!
+    totalWithdrawn: BigInt!
+
+    # Metadata
+    eventCount: Int!                     # Total events this day
+    lastUpdatedBlock: BigInt!            # Last block that updated this entity
+}
+
 # ============ Account - Snapshot Interfaces ============ #
 
 interface AccountSnapshotEntity implements SnapshotEntity {
@@ -164,6 +227,9 @@ type Account @entity(immutable: false) {
     groupMessages: [GroupMessage!] @derivedFrom(field: "account")
     identityUpdates: [IdentityUpdate!] @derivedFrom(field: "account")
     receivedDeposits: [ReceivedDeposit!] @derivedFrom(field: "recipient")
+
+    # Daily Time Series
+    dailyUsage: [DailyAccountUsage!] @derivedFrom(field: "account")
 }
 
 # ============ GroupMessageBroadcaster - Snapshot Interfaces ============ #

--- a/app-chain/src/common.ts
+++ b/app-chain/src/common.ts
@@ -1,6 +1,6 @@
 import { Address, BigInt } from '@graphprotocol/graph-ts';
 
-import { Account, FeesSnapshot } from '../generated/schema';
+import { Account, DailyAccountUsage, DailyGlobalUsage, FeesSnapshot } from '../generated/schema';
 
 export const ZERO_ADDRESS = Address.fromString('0x0000000000000000000000000000000000000000');
 
@@ -46,4 +46,96 @@ export function updateAccountFeesSnapshot(account: Account, timestamp: i32, valu
     snapshot.value = value;
 
     snapshot.save();
+}
+
+/* ============ Daily Time Series Helpers ============ */
+
+/**
+ * Converts a block timestamp (seconds since epoch) to a UTC date key (YYYY-MM-DD)
+ */
+export function getDateKey(timestamp: i32): string {
+    const SECONDS_PER_DAY = 86400;
+    const daysSinceEpoch = timestamp / SECONDS_PER_DAY;
+    const midnightTimestamp = daysSinceEpoch * SECONDS_PER_DAY;
+
+    // Convert to i64 before multiplying by 1000 to avoid i32 overflow
+    const date = new Date(i64(midnightTimestamp) * 1000);
+    const year = date.getUTCFullYear();
+    const month = date.getUTCMonth() + 1;
+    const day = date.getUTCDate();
+
+    const monthStr = month < 10 ? '0' + month.toString() : month.toString();
+    const dayStr = day < 10 ? '0' + day.toString() : day.toString();
+
+    return year.toString() + '-' + monthStr + '-' + dayStr;
+}
+
+/**
+ * Gets the midnight UTC timestamp for a given block timestamp
+ */
+export function getMidnightTimestamp(timestamp: i32): i32 {
+    const SECONDS_PER_DAY = 86400;
+    const daysSinceEpoch = timestamp / SECONDS_PER_DAY;
+    return daysSinceEpoch * SECONDS_PER_DAY;
+}
+
+/**
+ * Upserts a DailyAccountUsage entity for the given account and timestamp
+ */
+export function upsertDailyAccountUsage(account: Account, timestamp: i32, blockNumber: BigInt): DailyAccountUsage {
+    const dateKey = getDateKey(timestamp);
+    const id = `DailyAccountUsage-${account.address}-${dateKey}`;
+
+    let dailyUsage = DailyAccountUsage.load(id);
+
+    if (!dailyUsage) {
+        dailyUsage = new DailyAccountUsage(id);
+        dailyUsage.date = dateKey;
+        dailyUsage.dateTimestamp = getMidnightTimestamp(timestamp);
+        dailyUsage.account = account.id;
+
+        dailyUsage.groupMessagesSent = BigInt.fromI32(0);
+        dailyUsage.groupMessageBytesSent = BigInt.fromI32(0);
+        dailyUsage.groupMessageFees = BigInt.fromI32(0);
+        dailyUsage.identityUpdatesCreated = BigInt.fromI32(0);
+        dailyUsage.identityUpdateBytesCreated = BigInt.fromI32(0);
+        dailyUsage.identityUpdateFees = BigInt.fromI32(0);
+        dailyUsage.depositsReceived = BigInt.fromI32(0);
+        dailyUsage.totalFees = BigInt.fromI32(0);
+        dailyUsage.eventCount = 0;
+    }
+
+    dailyUsage.lastUpdatedBlock = blockNumber;
+
+    return dailyUsage;
+}
+
+/**
+ * Upserts a DailyGlobalUsage entity for the given timestamp
+ */
+export function upsertDailyGlobalUsage(timestamp: i32, blockNumber: BigInt): DailyGlobalUsage {
+    const dateKey = getDateKey(timestamp);
+    const id = `DailyGlobalUsage-${dateKey}`;
+
+    let dailyUsage = DailyGlobalUsage.load(id);
+
+    if (!dailyUsage) {
+        dailyUsage = new DailyGlobalUsage(id);
+        dailyUsage.date = dateKey;
+        dailyUsage.dateTimestamp = getMidnightTimestamp(timestamp);
+
+        dailyUsage.totalGroupMessagesSent = BigInt.fromI32(0);
+        dailyUsage.totalGroupMessageBytesSent = BigInt.fromI32(0);
+        dailyUsage.totalGroupMessageFees = BigInt.fromI32(0);
+        dailyUsage.totalIdentityUpdatesCreated = BigInt.fromI32(0);
+        dailyUsage.totalIdentityUpdateBytesCreated = BigInt.fromI32(0);
+        dailyUsage.totalIdentityUpdateFees = BigInt.fromI32(0);
+        dailyUsage.totalDepositsReceived = BigInt.fromI32(0);
+        dailyUsage.totalWithdrawn = BigInt.fromI32(0);
+        dailyUsage.eventCount = 0;
+    }
+
+    dailyUsage.lastUpdatedBlock = blockNumber;
+
+    return dailyUsage;
 }

--- a/app-chain/src/group-message-broadcaster.ts
+++ b/app-chain/src/group-message-broadcaster.ts
@@ -27,7 +27,13 @@ import {
     Upgraded as UpgradedEvent,
 } from '../generated/GroupMessageBroadcaster/GroupMessageBroadcaster';
 
-import { ZERO_ADDRESS, getAccount, updateAccountFeesSnapshot } from './common';
+import {
+    ZERO_ADDRESS,
+    getAccount,
+    updateAccountFeesSnapshot,
+    upsertDailyAccountUsage,
+    upsertDailyGlobalUsage,
+} from './common';
 
 const STARTING_IMPLEMENTATION = dataSource.context().getString('startingImplementation');
 
@@ -54,6 +60,26 @@ export function handleMessageSent(event: MessageSentEvent): void {
 
     account.fees = account.fees.plus(transactionFee);
     updateAccountFeesSnapshot(account, timestamp, account.fees);
+
+    // Update daily time series
+    const dailyAccountUsage = upsertDailyAccountUsage(account, timestamp, event.block.number);
+    dailyAccountUsage.groupMessagesSent = dailyAccountUsage.groupMessagesSent.plus(BigInt.fromI32(1));
+    dailyAccountUsage.groupMessageBytesSent = dailyAccountUsage.groupMessageBytesSent.plus(
+        BigInt.fromI32(messageLength)
+    );
+    dailyAccountUsage.groupMessageFees = dailyAccountUsage.groupMessageFees.plus(transactionFee);
+    dailyAccountUsage.totalFees = dailyAccountUsage.totalFees.plus(transactionFee);
+    dailyAccountUsage.eventCount += 1;
+    dailyAccountUsage.save();
+
+    const dailyGlobalUsage = upsertDailyGlobalUsage(timestamp, event.block.number);
+    dailyGlobalUsage.totalGroupMessagesSent = dailyGlobalUsage.totalGroupMessagesSent.plus(BigInt.fromI32(1));
+    dailyGlobalUsage.totalGroupMessageBytesSent = dailyGlobalUsage.totalGroupMessageBytesSent.plus(
+        BigInt.fromI32(messageLength)
+    );
+    dailyGlobalUsage.totalGroupMessageFees = dailyGlobalUsage.totalGroupMessageFees.plus(transactionFee);
+    dailyGlobalUsage.eventCount += 1;
+    dailyGlobalUsage.save();
 
     account.lastUpdate = timestamp;
     account.save();

--- a/app-chain/src/identity-update-broadcaster.ts
+++ b/app-chain/src/identity-update-broadcaster.ts
@@ -27,7 +27,13 @@ import {
     Upgraded as UpgradedEvent,
 } from '../generated/IdentityUpdateBroadcaster/IdentityUpdateBroadcaster';
 
-import { ZERO_ADDRESS, getAccount, updateAccountFeesSnapshot } from './common';
+import {
+    ZERO_ADDRESS,
+    getAccount,
+    updateAccountFeesSnapshot,
+    upsertDailyAccountUsage,
+    upsertDailyGlobalUsage,
+} from './common';
 
 const STARTING_IMPLEMENTATION = dataSource.context().getString('startingImplementation');
 /* ============ Handlers ============ */
@@ -53,6 +59,26 @@ export function handleIdentityUpdateCreated(event: IdentityUpdateCreatedEvent): 
 
     account.fees = account.fees.plus(transactionFee);
     updateAccountFeesSnapshot(account, timestamp, account.fees);
+
+    // Update daily time series
+    const dailyAccountUsage = upsertDailyAccountUsage(account, timestamp, event.block.number);
+    dailyAccountUsage.identityUpdatesCreated = dailyAccountUsage.identityUpdatesCreated.plus(BigInt.fromI32(1));
+    dailyAccountUsage.identityUpdateBytesCreated = dailyAccountUsage.identityUpdateBytesCreated.plus(
+        BigInt.fromI32(updateLength)
+    );
+    dailyAccountUsage.identityUpdateFees = dailyAccountUsage.identityUpdateFees.plus(transactionFee);
+    dailyAccountUsage.totalFees = dailyAccountUsage.totalFees.plus(transactionFee);
+    dailyAccountUsage.eventCount += 1;
+    dailyAccountUsage.save();
+
+    const dailyGlobalUsage = upsertDailyGlobalUsage(timestamp, event.block.number);
+    dailyGlobalUsage.totalIdentityUpdatesCreated = dailyGlobalUsage.totalIdentityUpdatesCreated.plus(BigInt.fromI32(1));
+    dailyGlobalUsage.totalIdentityUpdateBytesCreated = dailyGlobalUsage.totalIdentityUpdateBytesCreated.plus(
+        BigInt.fromI32(updateLength)
+    );
+    dailyGlobalUsage.totalIdentityUpdateFees = dailyGlobalUsage.totalIdentityUpdateFees.plus(transactionFee);
+    dailyGlobalUsage.eventCount += 1;
+    dailyGlobalUsage.save();
 
     account.lastUpdate = timestamp;
     account.save();

--- a/settlement-chain/abis/PayerRegistry.abi.json
+++ b/settlement-chain/abis/PayerRegistry.abi.json
@@ -690,6 +690,12 @@
     "name": "UsageSettled",
     "inputs": [
       {
+        "name": "payerReportId",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
         "name": "payer",
         "type": "address",
         "indexed": true,

--- a/settlement-chain/schema.graphql
+++ b/settlement-chain/schema.graphql
@@ -35,6 +35,54 @@ interface BooleanSnapshotEntity implements SnapshotEntity {
     value: Boolean!
 }
 
+# ============ Daily Time Series - Interface ============ #
+
+interface DailyTimeSeriesEntity {
+    id: ID! @unique
+    date: String! @index          # YYYY-MM-DD format
+    dateTimestamp: Timestamp! @index  # Midnight UTC timestamp
+}
+
+# ============ Payer - Daily Time Series ============ #
+
+type DailyPayerUsage implements DailyTimeSeriesEntity @entity(immutable: false) {
+    id: ID! @unique                      # Format: DailyPayerUsage-{payerAddress}-{YYYY-MM-DD}
+    date: String! @index                 # YYYY-MM-DD
+    dateTimestamp: Timestamp! @index     # Midnight UTC timestamp
+    payer: Payer! @index
+
+    # Daily deltas (NOT cumulative)
+    feesSettled: BigInt!                 # Total fees settled this day
+    deposited: BigInt!                   # Total deposited this day
+    withdrawn: BigInt!                   # Total withdrawn this day
+    incurredDebt: BigInt!                # Debt incurred this day
+    repaidDebt: BigInt!                  # Debt repaid this day
+
+    # Metadata
+    eventCount: Int!                     # Number of events this day
+    lastUpdatedBlock: BigInt!            # Last block that updated this entity
+}
+
+# ============ Global - Daily Time Series ============ #
+
+type DailyRegistryUsage implements DailyTimeSeriesEntity @entity(immutable: false) {
+    id: ID! @unique                      # Format: DailyRegistryUsage-{YYYY-MM-DD}
+    date: String! @index                 # YYYY-MM-DD
+    dateTimestamp: Timestamp! @index     # Midnight UTC timestamp
+
+    # Daily deltas (NOT cumulative)
+    totalDeposited: BigInt!              # Total deposited across all payers this day
+    totalWithdrawn: BigInt!              # Total withdrawn across all payers this day
+    totalUsageSettled: BigInt!           # Total usage settled across all payers this day
+    totalIncurredDebt: BigInt!           # Total debt incurred this day
+    totalRepaidDebt: BigInt!             # Total debt repaid this day
+    totalExcessTransferred: BigInt!      # Total excess transferred this day
+
+    # Metadata
+    eventCount: Int!                     # Total events this day
+    lastUpdatedBlock: BigInt!            # Last block that updated this entity
+}
+
 # ============ Payer - Snapshot Interfaces ============ #
 
 interface PayerSnapshotEntity implements SnapshotEntity {
@@ -161,6 +209,9 @@ type Payer @entity(immutable: false) {
     withdrawals: [PayerRegistryWithdrawal!] @derivedFrom(field: "payer")
     usageSettlements: [PayerRegistryUsageSettlement!] @derivedFrom(field: "payer")
     history: [History!] @derivedFrom(field: "payer")
+
+    # Daily Time Series
+    dailyUsage: [DailyPayerUsage!] @derivedFrom(field: "payer")
 }
 
 # ============ PayerRegistry - Snapshot Interfaces ============ #

--- a/settlement-chain/src/common.ts
+++ b/settlement-chain/src/common.ts
@@ -2,6 +2,9 @@ import { Address, BigInt, Timestamp, dataSource } from '@graphprotocol/graph-ts'
 
 import {
     Account,
+    DailyPayerUsage,
+    DailyRegistryUsage,
+    Payer,
     PayerRegistry,
     PayerRegistryExcessSnapshot,
     PayerRegistryTotalWithdrawableSnapshot,
@@ -125,4 +128,91 @@ export function _getExcess(payerRegistry: PayerRegistry): BigInt {
     return payerRegistryFeeTokenBalance.gt(payerRegistry.totalWithdrawable)
         ? payerRegistryFeeTokenBalance.minus(payerRegistry.totalWithdrawable)
         : BigInt.fromI32(0);
+}
+
+/* ============ Daily Time Series Helpers ============ */
+
+/**
+ * Converts a block timestamp (seconds since epoch) to a UTC date key (YYYY-MM-DD)
+ */
+export function getDateKey(timestamp: i32): string {
+    const SECONDS_PER_DAY = 86400;
+    const daysSinceEpoch = timestamp / SECONDS_PER_DAY;
+    const midnightTimestamp = daysSinceEpoch * SECONDS_PER_DAY;
+
+    // Convert to i64 before multiplying by 1000 to avoid i32 overflow
+    const date = new Date(i64(midnightTimestamp) * 1000);
+    const year = date.getUTCFullYear();
+    const month = date.getUTCMonth() + 1;
+    const day = date.getUTCDate();
+
+    const monthStr = month < 10 ? '0' + month.toString() : month.toString();
+    const dayStr = day < 10 ? '0' + day.toString() : day.toString();
+
+    return year.toString() + '-' + monthStr + '-' + dayStr;
+}
+
+/**
+ * Gets the midnight UTC timestamp for a given block timestamp
+ */
+export function getMidnightTimestamp(timestamp: i32): i32 {
+    const SECONDS_PER_DAY = 86400;
+    const daysSinceEpoch = timestamp / SECONDS_PER_DAY;
+    return daysSinceEpoch * SECONDS_PER_DAY;
+}
+
+/**
+ * Upserts a DailyPayerUsage entity for the given payer and timestamp
+ */
+export function upsertDailyPayerUsage(payer: Payer, timestamp: i32, blockNumber: BigInt): DailyPayerUsage {
+    const dateKey = getDateKey(timestamp);
+    const id = `DailyPayerUsage-${payer.address}-${dateKey}`;
+
+    let dailyUsage = DailyPayerUsage.load(id);
+
+    if (!dailyUsage) {
+        dailyUsage = new DailyPayerUsage(id);
+        dailyUsage.date = dateKey;
+        dailyUsage.dateTimestamp = getMidnightTimestamp(timestamp);
+        dailyUsage.payer = payer.id;
+
+        dailyUsage.feesSettled = BigInt.fromI32(0);
+        dailyUsage.deposited = BigInt.fromI32(0);
+        dailyUsage.withdrawn = BigInt.fromI32(0);
+        dailyUsage.incurredDebt = BigInt.fromI32(0);
+        dailyUsage.repaidDebt = BigInt.fromI32(0);
+        dailyUsage.eventCount = 0;
+    }
+
+    dailyUsage.lastUpdatedBlock = blockNumber;
+
+    return dailyUsage;
+}
+
+/**
+ * Upserts a DailyRegistryUsage entity for the given timestamp
+ */
+export function upsertDailyRegistryUsage(timestamp: i32, blockNumber: BigInt): DailyRegistryUsage {
+    const dateKey = getDateKey(timestamp);
+    const id = `DailyRegistryUsage-${dateKey}`;
+
+    let dailyUsage = DailyRegistryUsage.load(id);
+
+    if (!dailyUsage) {
+        dailyUsage = new DailyRegistryUsage(id);
+        dailyUsage.date = dateKey;
+        dailyUsage.dateTimestamp = getMidnightTimestamp(timestamp);
+
+        dailyUsage.totalDeposited = BigInt.fromI32(0);
+        dailyUsage.totalWithdrawn = BigInt.fromI32(0);
+        dailyUsage.totalUsageSettled = BigInt.fromI32(0);
+        dailyUsage.totalIncurredDebt = BigInt.fromI32(0);
+        dailyUsage.totalRepaidDebt = BigInt.fromI32(0);
+        dailyUsage.totalExcessTransferred = BigInt.fromI32(0);
+        dailyUsage.eventCount = 0;
+    }
+
+    dailyUsage.lastUpdatedBlock = blockNumber;
+
+    return dailyUsage;
 }

--- a/settlement-chain/src/payer-registry.ts
+++ b/settlement-chain/src/payer-registry.ts
@@ -48,7 +48,12 @@ import {
     Upgraded as UpgradedEvent,
 } from '../generated/PayerRegistry/PayerRegistry';
 
-import { getPayerRegistry, _updatePayerRegistryTotalWithdrawable } from './common';
+import {
+    getPayerRegistry,
+    upsertDailyPayerUsage,
+    upsertDailyRegistryUsage,
+    _updatePayerRegistryTotalWithdrawable,
+} from './common';
 
 /* ============ Handlers ============ */
 
@@ -59,6 +64,17 @@ export function handleDeposit(event: DepositEvent): void {
     const payer = getPayer(event.params.payer);
 
     _deposit(payerRegistry, payer, amount, timestamp);
+
+    // Update daily time series
+    const dailyPayerUsage = upsertDailyPayerUsage(payer, timestamp, event.block.number);
+    dailyPayerUsage.deposited = dailyPayerUsage.deposited.plus(amount);
+    dailyPayerUsage.eventCount += 1;
+    dailyPayerUsage.save();
+
+    const dailyRegistryUsage = upsertDailyRegistryUsage(timestamp, event.block.number);
+    dailyRegistryUsage.totalDeposited = dailyRegistryUsage.totalDeposited.plus(amount);
+    dailyRegistryUsage.eventCount += 1;
+    dailyRegistryUsage.save();
 
     payerRegistry.lastUpdate = timestamp;
     payerRegistry.save();
@@ -170,6 +186,17 @@ export function handleUsageSettled(event: UsageSettledEvent): void {
 
     _settleUsage(payerRegistry, payer, amount, timestamp);
 
+    // Update daily time series
+    const dailyPayerUsage = upsertDailyPayerUsage(payer, timestamp, event.block.number);
+    dailyPayerUsage.feesSettled = dailyPayerUsage.feesSettled.plus(amount);
+    dailyPayerUsage.eventCount += 1;
+    dailyPayerUsage.save();
+
+    const dailyRegistryUsage = upsertDailyRegistryUsage(timestamp, event.block.number);
+    dailyRegistryUsage.totalUsageSettled = dailyRegistryUsage.totalUsageSettled.plus(amount);
+    dailyRegistryUsage.eventCount += 1;
+    dailyRegistryUsage.save();
+
     payerRegistry.lastUpdate = timestamp;
     payerRegistry.save();
 
@@ -262,6 +289,17 @@ export function handleWithdrawalFinalized(event: WithdrawalFinalizedEvent): void
     if (!withdrawal) throw new Error('No pending withdrawal');
 
     _finalizeWithdrawal(payerRegistry, payer, withdrawal, timestamp);
+
+    // Update daily time series
+    const dailyPayerUsage = upsertDailyPayerUsage(payer, timestamp, event.block.number);
+    dailyPayerUsage.withdrawn = dailyPayerUsage.withdrawn.plus(withdrawal.amount);
+    dailyPayerUsage.eventCount += 1;
+    dailyPayerUsage.save();
+
+    const dailyRegistryUsage = upsertDailyRegistryUsage(timestamp, event.block.number);
+    dailyRegistryUsage.totalWithdrawn = dailyRegistryUsage.totalWithdrawn.plus(withdrawal.amount);
+    dailyRegistryUsage.eventCount += 1;
+    dailyRegistryUsage.save();
 
     payerRegistry.lastUpdate = timestamp;
     payerRegistry.save();

--- a/settlement-chain/testnet-staging.yaml
+++ b/settlement-chain/testnet-staging.yaml
@@ -8,7 +8,7 @@ dataSources:
       source:
           abi: PayerRegistry
           address: '0x208E94fbC9833B58765fedC30CFF8539C6356e88'
-          startBlock: 26900619
+          startBlock: 29155490
       context:
           startingImplementation:
               type: String
@@ -67,7 +67,7 @@ dataSources:
                 handler: handlePauseStatusUpdated
               - event: SettlerUpdated(indexed address)
                 handler: handleSettlerUpdated
-              - event: UsageSettled(indexed address,uint96)
+              - event: UsageSettled(indexed bytes32,indexed address,uint96)
                 handler: handleUsageSettled
               - event: WithdrawLockPeriodUpdated(uint32)
                 handler: handleWithdrawLockPeriodUpdated
@@ -84,8 +84,8 @@ dataSources:
       source:
           abi: FeeToken
           address: '0x63C6667798fdA65E2E29228C43fbfDa0Cd4634A8'
-          startBlock: 26900619
-          endBlock: 26900619 # Remove this when this is FeeToken/xUSD.
+          startBlock: 29155490
+          endBlock: 29155490 # Remove this when this is FeeToken/xUSD.
       context:
           payerRegistry:
               type: String

--- a/settlement-chain/testnet.yaml
+++ b/settlement-chain/testnet.yaml
@@ -8,7 +8,7 @@ dataSources:
       source:
           abi: PayerRegistry
           address: '0xF0bd6Ac8AA00BA083cF95C5438B33488cbd2562B'
-          startBlock: 26900619
+          startBlock: 29322100
       context:
           startingImplementation:
               type: String
@@ -67,7 +67,7 @@ dataSources:
                 handler: handlePauseStatusUpdated
               - event: SettlerUpdated(indexed address)
                 handler: handleSettlerUpdated
-              - event: UsageSettled(indexed address,uint96)
+              - event: UsageSettled(indexed bytes32,indexed address,uint96)
                 handler: handleUsageSettled
               - event: WithdrawLockPeriodUpdated(uint32)
                 handler: handleWithdrawLockPeriodUpdated
@@ -84,8 +84,8 @@ dataSources:
       source:
           abi: FeeToken
           address: '0x63C6667798fdA65E2E29228C43fbfDa0Cd4634A8'
-          startBlock: 26900619
-          endBlock: 26900619 # Remove this when this is FeeToken/xUSD.
+          startBlock: 29322100
+          endBlock: 29322100 # Remove this when this is FeeToken/xUSD.
       context:
           payerRegistry:
               type: String


### PR DESCRIPTION
# Add Daily Time Series Metrics and Fix Payer Report Indexing

  ## Changes
  - Added daily time series entities (`DailyAccountUsage`, `DailyGlobalUsage`, `DailyPayerUsage`, `DailyRegistryUsage`) to track daily aggregated metrics in UTC
  - Implemented daily tracking for group messages, identity updates, deposits, withdrawals, and fee settlements across both app-chain and settlement-chain subgraphs
  - Updated `UsageSettled` event handler to include `payerReportId` as indexed parameter for improved querying
  - Added helper functions for date key generation and midnight UTC timestamp calculations
  - Updated start blocks for testnet and testnet-staging deployments to reflect new contract deployments