### PR TITLE
Testnet Staging -> Testnet

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Goldsky API Key (get from https://app.goldsky.com/dashboard)
+GOLDSKY=your_goldsky_api_key_here
+
+# Goldsky Project ID
+PROJECT_ID=your_project_id_here
+
+# Subgraph version label (semantic versioning)
+VERSION_LABEL=v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,21 +9,26 @@
 
 ## Environment Setup
 - Node version: v20.19.5+ (engines.node: ">=23.2.0" in package.json)
-- Graph CLI: 0.97.1
-- Each subproject has `.env` files with DEPLOY_KEY and VERSION_LABEL
+- Graph CLI: 0.97.1 (for codegen and build)
+- Goldsky CLI: 3.1.0+ (for deployment)
+- Each subproject has `.env` files with:
+  - `VERSION_LABEL`: Semantic version for deployment (e.g., v0.2.5)
+  - `GOLDSKY`: API key for Goldsky authentication
+  - `PROJECT_ID`: Goldsky project identifier
 
 ## Environment Differences
 
-### testnet-dev vs testnet
-- **testnet-dev**: Development environment with test contract addresses, used for active development
-- **testnet**: Production testnet environment with different (production-ready) contract addresses
-- **testnet-staging**: Intermediate staging environment (settlement-chain only)
+### testnet-staging vs testnet
+- **testnet-staging**: Staging environment for testing before production deployment
+- **testnet**: Production testnet environment with production-ready contract addresses
 
 Key differences in contract addresses:
-- **App-chain**: Only has testnet-dev config (single environment)
-- **Settlement-chain**: Has all three environments with different PayerRegistry addresses:
-  - testnet-dev: `0x77a9129Cb584DF076a64A995dDEF9158d589D80c`
-  - testnet: `0x2B019EAfE0910a16394D78f3E930bB4c946B5E9e`
+- **App-chain**:
+  - testnet-staging: GroupMessageBroadcaster `0xdEB68688Fcc514b69078f2cCf0a6D2746548b368`, IdentityUpdateBroadcaster `0xe946A8e2DE66827e1834BA3c24D7f94c98249152`
+  - testnet: GroupMessageBroadcaster `0x6619B1c95eb10d339903E4AA9938314d6E711d17`, IdentityUpdateBroadcaster `0xD49DCDd95Ce435eaB2E53DBfcBceF5cAAc78D95a`
+- **Settlement-chain**:
+  - testnet-staging: PayerRegistry `0x208E94fbC9833B58765fedC30CFF8539C6356e88`
+  - testnet: PayerRegistry `0xF0bd6Ac8AA00BA083cF95C5438B33488cbd2562B`
 
 ## Common Commands
 
@@ -36,20 +41,36 @@ cd app-chain  # or settlement-chain
 yarn install
 
 # Code generation (choose environment)
-yarn codegen:testnet-dev    # Development environment
-yarn codegen:testnet-staging  # Staging (settlement-chain only)
-yarn codegen:testnet        # Production testnet
+yarn codegen:testnet-staging  # Staging environment
+yarn codegen:testnet          # Production testnet
 
 # Build subgraph
-yarn build:testnet-dev      # Development environment
-yarn build:testnet-staging  # Staging (settlement-chain only)
-yarn build:testnet         # Production testnet
+yarn build:testnet-staging    # Staging environment
+yarn build:testnet            # Production testnet
 
-# Deploy to Alchemy hosted service
-yarn deploy:testnet-dev     # Development environment
-yarn deploy:testnet-staging # Staging (settlement-chain only)
-yarn deploy:testnet        # Production testnet
+# Deploy to Goldsky
+yarn deploy:testnet-staging   # Deploys and tags with 'stable'
+yarn deploy:testnet           # Deploys and tags with 'stable'
 ```
+
+### How Deployment Works
+
+Deployments use Goldsky's versioning and tagging system:
+
+1. **Version**: Each deployment has a version (e.g., `v0.2.5`) specified in `.env`
+2. **Tag**: A stable tag (`stable`) is automatically created/updated to point to the deployed version
+3. **Endpoint**: Frontend always uses the tagged endpoint (e.g., `/stable/gn`), which never changes
+
+**Example**: When you run `yarn deploy:testnet-staging`:
+- Deploys `settlement-chain-testnet-staging/v0.2.5`
+- Creates/updates tag `stable` to point to `v0.2.5`
+- GraphQL endpoint: `https://api.goldsky.com/.../subgraphs/settlement-chain-testnet-staging/stable/gn`
+
+When deploying a new version (e.g., `v0.2.6`):
+- Update `VERSION_LABEL=v0.2.6` in `.env`
+- Run `yarn deploy:testnet-staging`
+- The `stable` tag automatically moves to `v0.2.6`
+- Frontend continues using the same endpoint URL
 
 ### Local Development:
 ```bash
@@ -65,36 +86,34 @@ yarn remove-local
 
 ## Deployment Configuration
 
-### Query Endpoints
-Use these **stable endpoints** that automatically point to the latest promoted version:
+### GraphQL Query Endpoints
 
-#### App-Chain Subgraph (testnet-dev):
-- **Stable Endpoint**: https://subgraph.satsuma-prod.com/ephemerahq/app-chain-testnet-dev/api
-- **Network**: xmtp-ropsten
-- **Config**: testnet-dev.yaml
+Use these **stable tagged endpoints** in your frontend applications. These URLs never change, even when deploying new subgraph versions.
 
-#### Settlement-Chain Subgraph (testnet-dev):
-- **Stable Endpoint**: https://subgraph.satsuma-prod.com/ephemerahq/settlement-chain-testnet-dev/api
+#### Settlement-Chain Subgraph (Base Sepolia)
+- **testnet-staging**: `https://api.goldsky.com/api/public/project_cmh3prjsr002wr4p22cdshlhh/subgraphs/settlement-chain-testnet-staging/stable/gn`
+- **testnet**: `https://api.goldsky.com/api/public/project_cmh3prjsr002wr4p22cdshlhh/subgraphs/settlement-chain-testnet/stable/gn`
 - **Network**: base-sepolia
-- **Config**: testnet-dev.yaml
+- **Current Version**: v0.2.5
 
-### Environment-specific Endpoints
-- **testnet-dev**: Currently active development environment (endpoints above)
-- **testnet-staging**: https://subgraph.satsuma-prod.com/ephemerahq/settlement-chain-testnet-staging/api (settlement-chain only)
-- **testnet**: https://subgraph.satsuma-prod.com/ephemerahq/settlement-chain-testnet/api (settlement-chain only)
+#### App-Chain Subgraph (XMTP Ropsten)
+- **testnet-staging**: `https://api.goldsky.com/api/public/project_cmh3prjsr002wr4p22cdshlhh/subgraphs/app-chain-testnet-staging/stable/gn`
+- **testnet**: `https://api.goldsky.com/api/public/project_cmh3prjsr002wr4p22cdshlhh/subgraphs/app-chain-testnet/stable/gn`
+- **Network**: xmtp-ropsten (Chain ID: 351243127)
+- **Current Version**: v0.2.4
+- **RPC**: xmtp-ropsten.g.alchemy.com/v2/VB4wowVdpg22Obz-gjoUhGJnGbjC67eN
 
-⚠️ **Important**: Always use the stable endpoints (without `/version/xxx`) for integration. Version-specific URLs change with each deployment.
+⚠️ **Important**: Always use the `/stable/gn` tagged endpoints. Never hardcode version numbers in your frontend code.
 
 ## Key Configuration Files
-- `testnet-dev.yaml` - Development environment configuration
 - `testnet-staging.yaml` - Staging environment configuration
 - `testnet.yaml` - Production testnet configuration
-- `.env` - Contains DEPLOY_KEY and VERSION_LABEL
+- `.env` - Contains VERSION_LABEL, GOLDSKY API key, and PROJECT_ID
 
 ## Deployment Infrastructure
-- **IPFS**: https://ipfs.satsuma.xyz
-- **Deploy Node**: https://subgraphs.alchemy.com/api/subgraphs/deploy
-- **Hosted Service**: Alchemy Subgraphs (Satsuma)
+- **Indexer**: Goldsky
+- **CLI**: @goldskycom/cli (via yarn)
+- **Project ID**: project_cmh3prjsr002wr4p22cdshlhh
 
 ## Data Tracked
 
@@ -123,8 +142,24 @@ yarn test
 yarn prettier
 ```
 
-## Recent Deployment Notes
-- Successfully deployed both subgraphs on Sep 16, 2025
-- Using version label: v0.1.1-testnet
-- Subgraphs are ready for funding portal integration
-- May take 10-15 minutes for initial sync after deployment
+## Troubleshooting
+
+### App-Chain Custom Network
+If you encounter "Subgraph network not supported: no network xmtp-ropsten found" error:
+- The xmtp-ropsten network (Chain ID: 351243127) must be configured in Goldsky
+- Contact Goldsky support if the network is not available
+- Provide: Chain ID 351243127 and RPC endpoint details
+
+### Version Already Exists
+If deployment fails with "You've already deployed this subgraph under the name X/vY.Z":
+- This typically means the subgraph content hash is identical to an existing deployment
+- Either make changes to the subgraph code, or
+- Update the `stable` tag to point to the existing version:
+  ```bash
+  yarn goldsky subgraph tag create <name>/<version> --tag stable --token <API_KEY>
+  ```
+
+### Deployment Takes Time
+- Initial deployment and indexing can take 10-15 minutes
+- The subgraph needs to sync with the blockchain from the startBlock specified in the yaml config
+- Check Goldsky dashboard for indexing progress

--- a/app-chain/abis/AppChainGateway.abi.json
+++ b/app-chain/abis/AppChainGateway.abi.json
@@ -1,172 +1,400 @@
 [
-    {
-        "type": "constructor",
-        "inputs": [
-            { "name": "parameterRegistry_", "type": "address", "internalType": "address" },
-            { "name": "settlementChainGateway_", "type": "address", "internalType": "address" }
-        ],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "implementation",
-        "inputs": [],
-        "outputs": [{ "name": "implementation_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    { "type": "function", "name": "initialize", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    { "type": "function", "name": "migrate", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "migratorParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "parameterRegistry",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "parameterRegistry_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "settlementChainGateway_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "implementation",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "implementation_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "migrate",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "migratorParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "parameterRegistry",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "paused",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "paused_",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "pausedParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "receiveDeposit",
+    "inputs": [
+      {
+        "name": "recipient_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "receiveParameters",
+    "inputs": [
+      {
+        "name": "nonce_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "keys_",
+        "type": "string[]",
+        "internalType": "string[]"
+      },
+      {
+        "name": "values_",
+        "type": "bytes32[]",
+        "internalType": "bytes32[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "settlementChainGateway",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "settlementChainGatewayAlias",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "updatePauseStatus",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "withdraw",
+    "inputs": [
+      {
+        "name": "recipient_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "withdrawIntoUnderlying",
+    "inputs": [
+      {
+        "name": "recipient_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "event",
+    "name": "DepositReceived",
+    "inputs": [
+      {
+        "name": "recipient",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Migrated",
+    "inputs": [
+      {
+        "name": "migrator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ParametersReceived",
+    "inputs": [
+      {
+        "name": "nonce",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "keys",
+        "type": "string[]",
+        "indexed": false,
+        "internalType": "string[]"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PauseStatusUpdated",
+    "inputs": [
+      {
         "name": "paused",
-        "inputs": [],
-        "outputs": [{ "name": "paused_", "type": "bool", "internalType": "bool" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "pausedParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "receiveDeposit",
-        "inputs": [{ "name": "recipient_", "type": "address", "internalType": "address" }],
-        "outputs": [],
-        "stateMutability": "payable"
-    },
-    {
-        "type": "function",
-        "name": "receiveParameters",
-        "inputs": [
-            { "name": "nonce_", "type": "uint256", "internalType": "uint256" },
-            { "name": "keys_", "type": "string[]", "internalType": "string[]" },
-            { "name": "values_", "type": "bytes32[]", "internalType": "bytes32[]" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "settlementChainGateway",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "settlementChainGatewayAlias",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    { "type": "function", "name": "updatePauseStatus", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "withdraw",
-        "inputs": [{ "name": "recipient_", "type": "address", "internalType": "address" }],
-        "outputs": [],
-        "stateMutability": "payable"
-    },
-    {
-        "type": "function",
-        "name": "withdrawIntoUnderlying",
-        "inputs": [{ "name": "recipient_", "type": "address", "internalType": "address" }],
-        "outputs": [],
-        "stateMutability": "payable"
-    },
-    {
-        "type": "event",
-        "name": "DepositReceived",
-        "inputs": [
-            { "name": "recipient", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "amount", "type": "uint256", "indexed": false, "internalType": "uint256" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Initialized",
-        "inputs": [{ "name": "version", "type": "uint64", "indexed": false, "internalType": "uint64" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Migrated",
-        "inputs": [{ "name": "migrator", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "ParametersReceived",
-        "inputs": [
-            { "name": "nonce", "type": "uint256", "indexed": true, "internalType": "uint256" },
-            { "name": "keys", "type": "string[]", "indexed": false, "internalType": "string[]" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "PauseStatusUpdated",
-        "inputs": [{ "name": "paused", "type": "bool", "indexed": true, "internalType": "bool" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Upgraded",
-        "inputs": [{ "name": "implementation", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Withdrawal",
-        "inputs": [
-            { "name": "account", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "messageId", "type": "uint256", "indexed": true, "internalType": "uint256" },
-            { "name": "recipient", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "amount", "type": "uint256", "indexed": false, "internalType": "uint256" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "error",
-        "name": "EmptyCode",
-        "inputs": [{ "name": "migrator_", "type": "address", "internalType": "address" }]
-    },
-    { "type": "error", "name": "InvalidInitialization", "inputs": [] },
-    {
-        "type": "error",
-        "name": "MigrationFailed",
-        "inputs": [
-            { "name": "migrator_", "type": "address", "internalType": "address" },
-            { "name": "revertData_", "type": "bytes", "internalType": "bytes" }
-        ]
-    },
-    { "type": "error", "name": "NoChange", "inputs": [] },
-    { "type": "error", "name": "NotInitializing", "inputs": [] },
-    { "type": "error", "name": "NotSettlementChainGateway", "inputs": [] },
-    { "type": "error", "name": "ParameterOutOfTypeBounds", "inputs": [] },
-    { "type": "error", "name": "Paused", "inputs": [] },
-    { "type": "error", "name": "TransferFailed", "inputs": [] },
-    { "type": "error", "name": "ZeroMigrator", "inputs": [] },
-    { "type": "error", "name": "ZeroParameterRegistry", "inputs": [] },
-    { "type": "error", "name": "ZeroRecipient", "inputs": [] },
-    { "type": "error", "name": "ZeroSettlementChainGateway", "inputs": [] },
-    { "type": "error", "name": "ZeroWithdrawalAmount", "inputs": [] }
+        "type": "bool",
+        "indexed": true,
+        "internalType": "bool"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Withdrawal",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "messageId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "recipient",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "EmptyCode",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InvalidInitialization",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MigrationFailed",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "revertData_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "NoChange",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotSettlementChainGateway",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ParameterOutOfTypeBounds",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Paused",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "TransferFailed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroMigrator",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroParameterRegistry",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroRecipient",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroSettlementChainGateway",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroWithdrawalAmount",
+    "inputs": []
+  }
 ]

--- a/app-chain/abis/AppChainParameterRegistry.abi.json
+++ b/app-chain/abis/AppChainParameterRegistry.abi.json
@@ -1,130 +1,305 @@
 [
-    {
-        "type": "function",
-        "name": "adminParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "get",
-        "inputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "outputs": [{ "name": "value_", "type": "bytes32", "internalType": "bytes32" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "get",
-        "inputs": [{ "name": "keys_", "type": "string[]", "internalType": "string[]" }],
-        "outputs": [{ "name": "values_", "type": "bytes32[]", "internalType": "bytes32[]" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
+  {
+    "type": "function",
+    "name": "adminParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "get",
+    "inputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "value_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "get",
+    "inputs": [
+      {
+        "name": "keys_",
+        "type": "string[]",
+        "internalType": "string[]"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "values_",
+        "type": "bytes32[]",
+        "internalType": "bytes32[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "implementation",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "implementation_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [
+      {
+        "name": "admins_",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "isAdmin",
+    "inputs": [
+      {
+        "name": "account_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "isAdmin_",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "migrate",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "migratorParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "set",
+    "inputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "value_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "set",
+    "inputs": [
+      {
+        "name": "keys_",
+        "type": "string[]",
+        "internalType": "string[]"
+      },
+      {
+        "name": "values_",
+        "type": "bytes32[]",
+        "internalType": "bytes32[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Migrated",
+    "inputs": [
+      {
+        "name": "migrator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ParameterSet",
+    "inputs": [
+      {
+        "name": "key",
+        "type": "string",
+        "indexed": true,
+        "internalType": "string"
+      },
+      {
+        "name": "value",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
         "name": "implementation",
-        "inputs": [],
-        "outputs": [{ "name": "implementation_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "initialize",
-        "inputs": [{ "name": "admins_", "type": "address[]", "internalType": "address[]" }],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "isAdmin",
-        "inputs": [{ "name": "account_", "type": "address", "internalType": "address" }],
-        "outputs": [{ "name": "isAdmin_", "type": "bool", "internalType": "bool" }],
-        "stateMutability": "view"
-    },
-    { "type": "function", "name": "migrate", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "migratorParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "set",
-        "inputs": [
-            { "name": "key_", "type": "string", "internalType": "string" },
-            { "name": "value_", "type": "bytes32", "internalType": "bytes32" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "set",
-        "inputs": [
-            { "name": "keys_", "type": "string[]", "internalType": "string[]" },
-            { "name": "values_", "type": "bytes32[]", "internalType": "bytes32[]" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "event",
-        "name": "Initialized",
-        "inputs": [{ "name": "version", "type": "uint64", "indexed": false, "internalType": "uint64" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Migrated",
-        "inputs": [{ "name": "migrator", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "ParameterSet",
-        "inputs": [
-            { "name": "key", "type": "string", "indexed": true, "internalType": "string" },
-            { "name": "value", "type": "bytes32", "indexed": true, "internalType": "bytes32" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Upgraded",
-        "inputs": [{ "name": "implementation", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    { "type": "error", "name": "ArrayLengthMismatch", "inputs": [] },
-    { "type": "error", "name": "EmptyAdmins", "inputs": [] },
-    {
-        "type": "error",
-        "name": "EmptyCode",
-        "inputs": [{ "name": "migrator_", "type": "address", "internalType": "address" }]
-    },
-    { "type": "error", "name": "InvalidInitialization", "inputs": [] },
-    {
-        "type": "error",
-        "name": "MigrationFailed",
-        "inputs": [
-            { "name": "migrator_", "type": "address", "internalType": "address" },
-            { "name": "revertData_", "type": "bytes", "internalType": "bytes" }
-        ]
-    },
-    { "type": "error", "name": "NoKeyComponents", "inputs": [] },
-    { "type": "error", "name": "NoKeys", "inputs": [] },
-    { "type": "error", "name": "NotAdmin", "inputs": [] },
-    { "type": "error", "name": "NotInitializing", "inputs": [] },
-    { "type": "error", "name": "ParameterOutOfTypeBounds", "inputs": [] },
-    {
-        "type": "error",
-        "name": "StringsInsufficientHexLength",
-        "inputs": [
-            { "name": "value", "type": "uint256", "internalType": "uint256" },
-            { "name": "length", "type": "uint256", "internalType": "uint256" }
-        ]
-    },
-    { "type": "error", "name": "ZeroAdmin", "inputs": [] },
-    { "type": "error", "name": "ZeroMigrator", "inputs": [] }
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "ArrayLengthMismatch",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "EmptyAdmins",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "EmptyCode",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InvalidInitialization",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MigrationFailed",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "revertData_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "NoKeyComponents",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NoKeys",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotAdmin",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ParameterOutOfTypeBounds",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "StringsInsufficientHexLength",
+    "inputs": [
+      {
+        "name": "value",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "length",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ZeroAdmin",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroMigrator",
+    "inputs": []
+  }
 ]

--- a/app-chain/abis/Factory.abi.json
+++ b/app-chain/abis/Factory.abi.json
@@ -1,153 +1,376 @@
 [
-    {
-        "type": "constructor",
-        "inputs": [{ "name": "parameterRegistry_", "type": "address", "internalType": "address" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "computeImplementationAddress",
-        "inputs": [{ "name": "bytecode_", "type": "bytes", "internalType": "bytes" }],
-        "outputs": [{ "name": "implementation_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "computeProxyAddress",
-        "inputs": [
-            { "name": "caller_", "type": "address", "internalType": "address" },
-            { "name": "salt_", "type": "bytes32", "internalType": "bytes32" }
-        ],
-        "outputs": [{ "name": "proxy_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "deployImplementation",
-        "inputs": [{ "name": "bytecode_", "type": "bytes", "internalType": "bytes" }],
-        "outputs": [{ "name": "implementation_", "type": "address", "internalType": "address" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "deployProxy",
-        "inputs": [
-            { "name": "implementation_", "type": "address", "internalType": "address" },
-            { "name": "salt_", "type": "bytes32", "internalType": "bytes32" },
-            { "name": "initializeCallData_", "type": "bytes", "internalType": "bytes" }
-        ],
-        "outputs": [{ "name": "proxy_", "type": "address", "internalType": "address" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "parameterRegistry_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "computeImplementationAddress",
+    "inputs": [
+      {
+        "name": "bytecode_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "implementation_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "computeProxyAddress",
+    "inputs": [
+      {
+        "name": "caller_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "salt_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "proxy_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "deployImplementation",
+    "inputs": [
+      {
+        "name": "bytecode_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "implementation_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "deployProxy",
+    "inputs": [
+      {
+        "name": "implementation_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "salt_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "initializeCallData_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "proxy_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "implementation",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "implementation_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initializableImplementation",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "initializableImplementation_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "migrate",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "migratorParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "parameterRegistry",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "paused",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "paused_",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "pausedParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "event",
+    "name": "ImplementationDeployed",
+    "inputs": [
+      {
         "name": "implementation",
-        "inputs": [],
-        "outputs": [{ "name": "implementation_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "initializableImplementation",
-        "inputs": [],
-        "outputs": [{ "name": "initializableImplementation_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    { "type": "function", "name": "initialize", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    { "type": "function", "name": "migrate", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "migratorParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "parameterRegistry",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "paused",
-        "inputs": [],
-        "outputs": [{ "name": "paused_", "type": "bool", "internalType": "bool" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "pausedParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "event",
-        "name": "ImplementationDeployed",
-        "inputs": [
-            { "name": "implementation", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "bytecodeHash", "type": "bytes32", "indexed": true, "internalType": "bytes32" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "InitializableImplementationDeployed",
-        "inputs": [{ "name": "implementation", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Initialized",
-        "inputs": [{ "name": "version", "type": "uint64", "indexed": false, "internalType": "uint64" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Migrated",
-        "inputs": [{ "name": "migrator", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "ProxyDeployed",
-        "inputs": [
-            { "name": "proxy", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "implementation", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "sender", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "salt", "type": "bytes32", "indexed": false, "internalType": "bytes32" },
-            { "name": "initializeCallData", "type": "bytes", "indexed": false, "internalType": "bytes" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Upgraded",
-        "inputs": [{ "name": "implementation", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    { "type": "error", "name": "DeployFailed", "inputs": [] },
-    { "type": "error", "name": "EmptyBytecode", "inputs": [] },
-    {
-        "type": "error",
-        "name": "EmptyCode",
-        "inputs": [{ "name": "migrator_", "type": "address", "internalType": "address" }]
-    },
-    { "type": "error", "name": "InvalidImplementation", "inputs": [] },
-    { "type": "error", "name": "InvalidInitialization", "inputs": [] },
-    {
-        "type": "error",
-        "name": "MigrationFailed",
-        "inputs": [
-            { "name": "migrator_", "type": "address", "internalType": "address" },
-            { "name": "revertData_", "type": "bytes", "internalType": "bytes" }
-        ]
-    },
-    { "type": "error", "name": "NotInitializing", "inputs": [] },
-    { "type": "error", "name": "ParameterOutOfTypeBounds", "inputs": [] },
-    { "type": "error", "name": "Paused", "inputs": [] },
-    { "type": "error", "name": "ZeroMigrator", "inputs": [] },
-    { "type": "error", "name": "ZeroParameterRegistry", "inputs": [] }
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "bytecodeHash",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "InitializableImplementationDeployed",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Migrated",
+    "inputs": [
+      {
+        "name": "migrator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ProxyDeployed",
+    "inputs": [
+      {
+        "name": "proxy",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "sender",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "salt",
+        "type": "bytes32",
+        "indexed": false,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "initializeCallData",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "DeployFailed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "EmptyBytecode",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "EmptyCode",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InvalidImplementation",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidInitialization",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MigrationFailed",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "revertData_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ParameterOutOfTypeBounds",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Paused",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroMigrator",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroParameterRegistry",
+    "inputs": []
+  }
 ]

--- a/app-chain/abis/GroupMessageBroadcaster.abi.json
+++ b/app-chain/abis/GroupMessageBroadcaster.abi.json
@@ -1,216 +1,468 @@
 [
-    {
-        "type": "constructor",
-        "inputs": [{ "name": "parameterRegistry_", "type": "address", "internalType": "address" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "addMessage",
-        "inputs": [
-            { "name": "groupId_", "type": "bytes16", "internalType": "bytes16" },
-            { "name": "message_", "type": "bytes", "internalType": "bytes" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "bootstrapMessages",
-        "inputs": [
-            { "name": "groupIds_", "type": "bytes16[]", "internalType": "bytes16[]" },
-            { "name": "messages_", "type": "bytes[]", "internalType": "bytes[]" },
-            { "name": "sequenceIds_", "type": "uint64[]", "internalType": "uint64[]" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "implementation",
-        "inputs": [],
-        "outputs": [{ "name": "implementation_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    { "type": "function", "name": "initialize", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "maxPayloadSize",
-        "inputs": [],
-        "outputs": [{ "name": "size_", "type": "uint32", "internalType": "uint32" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "maxPayloadSizeParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    { "type": "function", "name": "migrate", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "migratorParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "minPayloadSize",
-        "inputs": [],
-        "outputs": [{ "name": "size_", "type": "uint32", "internalType": "uint32" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "minPayloadSizeParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "parameterRegistry",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "parameterRegistry_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "addMessage",
+    "inputs": [
+      {
+        "name": "groupId_",
+        "type": "bytes16",
+        "internalType": "bytes16"
+      },
+      {
+        "name": "message_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "bootstrapMessages",
+    "inputs": [
+      {
+        "name": "groupIds_",
+        "type": "bytes16[]",
+        "internalType": "bytes16[]"
+      },
+      {
+        "name": "messages_",
+        "type": "bytes[]",
+        "internalType": "bytes[]"
+      },
+      {
+        "name": "sequenceIds_",
+        "type": "uint64[]",
+        "internalType": "uint64[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "implementation",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "implementation_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "maxPayloadSize",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "size_",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "maxPayloadSizeParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "migrate",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "migratorParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "minPayloadSize",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "size_",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "minPayloadSizeParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "parameterRegistry",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "paused",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "paused_",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "pausedParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "payloadBootstrapper",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "payloadBootstrapper_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "payloadBootstrapperParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "updateMaxPayloadSize",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateMinPayloadSize",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updatePauseStatus",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updatePayloadBootstrapper",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "MaxPayloadSizeUpdated",
+    "inputs": [
+      {
+        "name": "size",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "MessageSent",
+    "inputs": [
+      {
+        "name": "groupId",
+        "type": "bytes16",
+        "indexed": true,
+        "internalType": "bytes16"
+      },
+      {
+        "name": "message",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      },
+      {
+        "name": "sequenceId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Migrated",
+    "inputs": [
+      {
+        "name": "migrator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "MinPayloadSizeUpdated",
+    "inputs": [
+      {
+        "name": "size",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PauseStatusUpdated",
+    "inputs": [
+      {
         "name": "paused",
-        "inputs": [],
-        "outputs": [{ "name": "paused_", "type": "bool", "internalType": "bool" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "pausedParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
+        "type": "bool",
+        "indexed": true,
+        "internalType": "bool"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PayloadBootstrapperUpdated",
+    "inputs": [
+      {
         "name": "payloadBootstrapper",
-        "inputs": [],
-        "outputs": [{ "name": "payloadBootstrapper_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "payloadBootstrapperParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "updateMaxPayloadSize",
-        "inputs": [],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "updateMinPayloadSize",
-        "inputs": [],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    { "type": "function", "name": "updatePauseStatus", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "updatePayloadBootstrapper",
-        "inputs": [],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "event",
-        "name": "Initialized",
-        "inputs": [{ "name": "version", "type": "uint64", "indexed": false, "internalType": "uint64" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "MaxPayloadSizeUpdated",
-        "inputs": [{ "name": "size", "type": "uint256", "indexed": true, "internalType": "uint256" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "MessageSent",
-        "inputs": [
-            { "name": "groupId", "type": "bytes16", "indexed": true, "internalType": "bytes16" },
-            { "name": "message", "type": "bytes", "indexed": false, "internalType": "bytes" },
-            { "name": "sequenceId", "type": "uint64", "indexed": true, "internalType": "uint64" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Migrated",
-        "inputs": [{ "name": "migrator", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "MinPayloadSizeUpdated",
-        "inputs": [{ "name": "size", "type": "uint256", "indexed": true, "internalType": "uint256" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "PauseStatusUpdated",
-        "inputs": [{ "name": "paused", "type": "bool", "indexed": true, "internalType": "bool" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "PayloadBootstrapperUpdated",
-        "inputs": [{ "name": "payloadBootstrapper", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Upgraded",
-        "inputs": [{ "name": "implementation", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    { "type": "error", "name": "ArrayLengthMismatch", "inputs": [] },
-    { "type": "error", "name": "EmptyArray", "inputs": [] },
-    {
-        "type": "error",
-        "name": "EmptyCode",
-        "inputs": [{ "name": "migrator_", "type": "address", "internalType": "address" }]
-    },
-    { "type": "error", "name": "InvalidInitialization", "inputs": [] },
-    { "type": "error", "name": "InvalidMaxPayloadSize", "inputs": [] },
-    { "type": "error", "name": "InvalidMinPayloadSize", "inputs": [] },
-    {
-        "type": "error",
-        "name": "InvalidPayloadSize",
-        "inputs": [
-            { "name": "actualSize_", "type": "uint256", "internalType": "uint256" },
-            { "name": "minSize_", "type": "uint256", "internalType": "uint256" },
-            { "name": "maxSize_", "type": "uint256", "internalType": "uint256" }
-        ]
-    },
-    {
-        "type": "error",
-        "name": "MigrationFailed",
-        "inputs": [
-            { "name": "migrator_", "type": "address", "internalType": "address" },
-            { "name": "revertData_", "type": "bytes", "internalType": "bytes" }
-        ]
-    },
-    { "type": "error", "name": "NoChange", "inputs": [] },
-    { "type": "error", "name": "NotInitializing", "inputs": [] },
-    { "type": "error", "name": "NotPaused", "inputs": [] },
-    { "type": "error", "name": "NotPayloadBootstrapper", "inputs": [] },
-    { "type": "error", "name": "ParameterOutOfTypeBounds", "inputs": [] },
-    { "type": "error", "name": "Paused", "inputs": [] },
-    { "type": "error", "name": "ZeroMigrator", "inputs": [] },
-    { "type": "error", "name": "ZeroParameterRegistry", "inputs": [] }
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "ArrayLengthMismatch",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "EmptyArray",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "EmptyCode",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InvalidInitialization",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidMaxPayloadSize",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidMinPayloadSize",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidPayloadSize",
+    "inputs": [
+      {
+        "name": "actualSize_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "minSize_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "maxSize_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "MigrationFailed",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "revertData_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "NoChange",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotPaused",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotPayloadBootstrapper",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ParameterOutOfTypeBounds",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Paused",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroMigrator",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroParameterRegistry",
+    "inputs": []
+  }
 ]

--- a/app-chain/abis/IdentityUpdateBroadcaster.abi.json
+++ b/app-chain/abis/IdentityUpdateBroadcaster.abi.json
@@ -1,216 +1,468 @@
 [
-    {
-        "type": "constructor",
-        "inputs": [{ "name": "parameterRegistry_", "type": "address", "internalType": "address" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "addIdentityUpdate",
-        "inputs": [
-            { "name": "inboxId_", "type": "bytes32", "internalType": "bytes32" },
-            { "name": "identityUpdate_", "type": "bytes", "internalType": "bytes" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "bootstrapIdentityUpdates",
-        "inputs": [
-            { "name": "inboxIds_", "type": "bytes32[]", "internalType": "bytes32[]" },
-            { "name": "identityUpdates_", "type": "bytes[]", "internalType": "bytes[]" },
-            { "name": "sequenceIds_", "type": "uint64[]", "internalType": "uint64[]" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "implementation",
-        "inputs": [],
-        "outputs": [{ "name": "implementation_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    { "type": "function", "name": "initialize", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "maxPayloadSize",
-        "inputs": [],
-        "outputs": [{ "name": "size_", "type": "uint32", "internalType": "uint32" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "maxPayloadSizeParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    { "type": "function", "name": "migrate", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "migratorParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "minPayloadSize",
-        "inputs": [],
-        "outputs": [{ "name": "size_", "type": "uint32", "internalType": "uint32" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "minPayloadSizeParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "parameterRegistry",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "parameterRegistry_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "addIdentityUpdate",
+    "inputs": [
+      {
+        "name": "inboxId_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "identityUpdate_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "bootstrapIdentityUpdates",
+    "inputs": [
+      {
+        "name": "inboxIds_",
+        "type": "bytes32[]",
+        "internalType": "bytes32[]"
+      },
+      {
+        "name": "identityUpdates_",
+        "type": "bytes[]",
+        "internalType": "bytes[]"
+      },
+      {
+        "name": "sequenceIds_",
+        "type": "uint64[]",
+        "internalType": "uint64[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "implementation",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "implementation_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "maxPayloadSize",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "size_",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "maxPayloadSizeParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "migrate",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "migratorParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "minPayloadSize",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "size_",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "minPayloadSizeParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "parameterRegistry",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "paused",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "paused_",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "pausedParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "payloadBootstrapper",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "payloadBootstrapper_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "payloadBootstrapperParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "updateMaxPayloadSize",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateMinPayloadSize",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updatePauseStatus",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updatePayloadBootstrapper",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "IdentityUpdateCreated",
+    "inputs": [
+      {
+        "name": "inboxId",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "update",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      },
+      {
+        "name": "sequenceId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "MaxPayloadSizeUpdated",
+    "inputs": [
+      {
+        "name": "size",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Migrated",
+    "inputs": [
+      {
+        "name": "migrator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "MinPayloadSizeUpdated",
+    "inputs": [
+      {
+        "name": "size",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PauseStatusUpdated",
+    "inputs": [
+      {
         "name": "paused",
-        "inputs": [],
-        "outputs": [{ "name": "paused_", "type": "bool", "internalType": "bool" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "pausedParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
+        "type": "bool",
+        "indexed": true,
+        "internalType": "bool"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PayloadBootstrapperUpdated",
+    "inputs": [
+      {
         "name": "payloadBootstrapper",
-        "inputs": [],
-        "outputs": [{ "name": "payloadBootstrapper_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "payloadBootstrapperParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "updateMaxPayloadSize",
-        "inputs": [],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "updateMinPayloadSize",
-        "inputs": [],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    { "type": "function", "name": "updatePauseStatus", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "updatePayloadBootstrapper",
-        "inputs": [],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "event",
-        "name": "IdentityUpdateCreated",
-        "inputs": [
-            { "name": "inboxId", "type": "bytes32", "indexed": true, "internalType": "bytes32" },
-            { "name": "update", "type": "bytes", "indexed": false, "internalType": "bytes" },
-            { "name": "sequenceId", "type": "uint64", "indexed": true, "internalType": "uint64" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Initialized",
-        "inputs": [{ "name": "version", "type": "uint64", "indexed": false, "internalType": "uint64" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "MaxPayloadSizeUpdated",
-        "inputs": [{ "name": "size", "type": "uint256", "indexed": true, "internalType": "uint256" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Migrated",
-        "inputs": [{ "name": "migrator", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "MinPayloadSizeUpdated",
-        "inputs": [{ "name": "size", "type": "uint256", "indexed": true, "internalType": "uint256" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "PauseStatusUpdated",
-        "inputs": [{ "name": "paused", "type": "bool", "indexed": true, "internalType": "bool" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "PayloadBootstrapperUpdated",
-        "inputs": [{ "name": "payloadBootstrapper", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Upgraded",
-        "inputs": [{ "name": "implementation", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    { "type": "error", "name": "ArrayLengthMismatch", "inputs": [] },
-    { "type": "error", "name": "EmptyArray", "inputs": [] },
-    {
-        "type": "error",
-        "name": "EmptyCode",
-        "inputs": [{ "name": "migrator_", "type": "address", "internalType": "address" }]
-    },
-    { "type": "error", "name": "InvalidInitialization", "inputs": [] },
-    { "type": "error", "name": "InvalidMaxPayloadSize", "inputs": [] },
-    { "type": "error", "name": "InvalidMinPayloadSize", "inputs": [] },
-    {
-        "type": "error",
-        "name": "InvalidPayloadSize",
-        "inputs": [
-            { "name": "actualSize_", "type": "uint256", "internalType": "uint256" },
-            { "name": "minSize_", "type": "uint256", "internalType": "uint256" },
-            { "name": "maxSize_", "type": "uint256", "internalType": "uint256" }
-        ]
-    },
-    {
-        "type": "error",
-        "name": "MigrationFailed",
-        "inputs": [
-            { "name": "migrator_", "type": "address", "internalType": "address" },
-            { "name": "revertData_", "type": "bytes", "internalType": "bytes" }
-        ]
-    },
-    { "type": "error", "name": "NoChange", "inputs": [] },
-    { "type": "error", "name": "NotInitializing", "inputs": [] },
-    { "type": "error", "name": "NotPaused", "inputs": [] },
-    { "type": "error", "name": "NotPayloadBootstrapper", "inputs": [] },
-    { "type": "error", "name": "ParameterOutOfTypeBounds", "inputs": [] },
-    { "type": "error", "name": "Paused", "inputs": [] },
-    { "type": "error", "name": "ZeroMigrator", "inputs": [] },
-    { "type": "error", "name": "ZeroParameterRegistry", "inputs": [] }
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "ArrayLengthMismatch",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "EmptyArray",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "EmptyCode",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InvalidInitialization",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidMaxPayloadSize",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidMinPayloadSize",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidPayloadSize",
+    "inputs": [
+      {
+        "name": "actualSize_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "minSize_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "maxSize_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "MigrationFailed",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "revertData_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "NoChange",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotPaused",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotPayloadBootstrapper",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ParameterOutOfTypeBounds",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Paused",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroMigrator",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroParameterRegistry",
+    "inputs": []
+  }
 ]

--- a/app-chain/package.json
+++ b/app-chain/package.json
@@ -8,8 +8,8 @@
         "codegen:testnet": "graph codegen testnet.yaml",
         "build:testnet-staging": "graph build testnet-staging.yaml",
         "build:testnet": "graph build testnet.yaml",
-        "deploy:testnet-staging": "graph deploy app-chain-testnet-staging testnet-staging.yaml --ipfs https://ipfs.satsuma.xyz --version-label $(grep VERSION_LABEL .env | cut -d '=' -f2) --node https://subgraphs.alchemy.com/api/subgraphs/deploy --deploy-key $(grep DEPLOY_KEY .env | cut -d '=' -f2)",
-        "deploy:testnet": "graph deploy app-chain-testnet testnet.yaml --ipfs https://ipfs.satsuma.xyz --version-label $(grep VERSION_LABEL .env | cut -d '=' -f2) --node https://subgraphs.alchemy.com/api/subgraphs/deploy --deploy-key $(grep DEPLOY_KEY .env | cut -d '=' -f2)",
+        "deploy:testnet-staging": "goldsky subgraph deploy app-chain-testnet-staging/$(grep VERSION_LABEL .env | cut -d '=' -f2) --path ./build --token $(grep GOLDSKY .env | cut -d '=' -f2) && goldsky subgraph tag create app-chain-testnet-staging/$(grep VERSION_LABEL .env | cut -d '=' -f2) --tag stable --token $(grep GOLDSKY .env | cut -d '=' -f2)",
+        "deploy:testnet": "goldsky subgraph deploy app-chain-testnet/$(grep VERSION_LABEL .env | cut -d '=' -f2) --path ./build --token $(grep GOLDSKY .env | cut -d '=' -f2) && goldsky subgraph tag create app-chain-testnet/$(grep VERSION_LABEL .env | cut -d '=' -f2) --tag stable --token $(grep GOLDSKY .env | cut -d '=' -f2)",
         "create-local": "graph create --node http://localhost:8020/ xmtp/app-chain",
         "remove-local": "graph remove --node http://localhost:8020/ xmtp/app-chain",
         "deploy-local": "graph deploy --node http://localhost:8020/ xmtp/app-chain",
@@ -18,6 +18,7 @@
     },
     "dependencies": {},
     "devDependencies": {
+        "@goldskycom/cli": "^3.1.0",
         "@graphprotocol/graph-cli": "^0.97.1",
         "@graphprotocol/graph-ts": "^0.38.1",
         "dotenv": "^16.5.0",

--- a/app-chain/schema.graphql
+++ b/app-chain/schema.graphql
@@ -35,6 +35,69 @@ interface BooleanSnapshotEntity implements SnapshotEntity {
     value: Boolean!
 }
 
+# ============ Daily Time Series - Interface ============ #
+
+interface DailyTimeSeriesEntity {
+    id: ID! @unique
+    date: String! @index          # YYYY-MM-DD format
+    dateTimestamp: Timestamp! @index  # Midnight UTC timestamp
+}
+
+# ============ Account - Daily Time Series ============ #
+
+type DailyAccountUsage implements DailyTimeSeriesEntity @entity(immutable: false) {
+    id: ID! @unique                      # Format: DailyAccountUsage-{accountAddress}-{YYYY-MM-DD}
+    date: String! @index                 # YYYY-MM-DD
+    dateTimestamp: Timestamp! @index     # Midnight UTC timestamp
+    account: Account! @index
+
+    # Daily deltas for group messages (NOT cumulative)
+    groupMessagesSent: BigInt!           # Messages sent this day
+    groupMessageBytesSent: BigInt!       # Bytes sent this day
+    groupMessageFees: BigInt!            # Gas fees for messages this day
+
+    # Daily deltas for identity updates (NOT cumulative)
+    identityUpdatesCreated: BigInt!      # Identity updates this day
+    identityUpdateBytesCreated: BigInt!  # Identity update bytes this day
+    identityUpdateFees: BigInt!          # Gas fees for identity updates this day
+
+    # Daily deltas for cross-chain operations
+    depositsReceived: BigInt!            # Deposits received this day
+
+    # Aggregated daily fees
+    totalFees: BigInt!                   # Total gas fees this day
+
+    # Metadata
+    eventCount: Int!                     # Number of events this day
+    lastUpdatedBlock: BigInt!            # Last block that updated this entity
+}
+
+# ============ Global - Daily Time Series ============ #
+
+type DailyGlobalUsage implements DailyTimeSeriesEntity @entity(immutable: false) {
+    id: ID! @unique                      # Format: DailyGlobalUsage-{YYYY-MM-DD}
+    date: String! @index                 # YYYY-MM-DD
+    dateTimestamp: Timestamp! @index     # Midnight UTC timestamp
+
+    # Daily deltas for group messages (NOT cumulative)
+    totalGroupMessagesSent: BigInt!
+    totalGroupMessageBytesSent: BigInt!
+    totalGroupMessageFees: BigInt!
+
+    # Daily deltas for identity updates (NOT cumulative)
+    totalIdentityUpdatesCreated: BigInt!
+    totalIdentityUpdateBytesCreated: BigInt!
+    totalIdentityUpdateFees: BigInt!
+
+    # Daily deltas for cross-chain operations
+    totalDepositsReceived: BigInt!
+    totalWithdrawn: BigInt!
+
+    # Metadata
+    eventCount: Int!                     # Total events this day
+    lastUpdatedBlock: BigInt!            # Last block that updated this entity
+}
+
 # ============ Account - Snapshot Interfaces ============ #
 
 interface AccountSnapshotEntity implements SnapshotEntity {
@@ -164,6 +227,9 @@ type Account @entity(immutable: false) {
     groupMessages: [GroupMessage!] @derivedFrom(field: "account")
     identityUpdates: [IdentityUpdate!] @derivedFrom(field: "account")
     receivedDeposits: [ReceivedDeposit!] @derivedFrom(field: "recipient")
+
+    # Daily Time Series
+    dailyUsage: [DailyAccountUsage!] @derivedFrom(field: "account")
 }
 
 # ============ GroupMessageBroadcaster - Snapshot Interfaces ============ #

--- a/app-chain/src/common.ts
+++ b/app-chain/src/common.ts
@@ -1,6 +1,6 @@
 import { Address, BigInt } from '@graphprotocol/graph-ts';
 
-import { Account, FeesSnapshot } from '../generated/schema';
+import { Account, DailyAccountUsage, DailyGlobalUsage, FeesSnapshot } from '../generated/schema';
 
 export const ZERO_ADDRESS = Address.fromString('0x0000000000000000000000000000000000000000');
 
@@ -46,4 +46,96 @@ export function updateAccountFeesSnapshot(account: Account, timestamp: i32, valu
     snapshot.value = value;
 
     snapshot.save();
+}
+
+/* ============ Daily Time Series Helpers ============ */
+
+/**
+ * Converts a block timestamp (seconds since epoch) to a UTC date key (YYYY-MM-DD)
+ */
+export function getDateKey(timestamp: i32): string {
+    const SECONDS_PER_DAY = 86400;
+    const daysSinceEpoch = timestamp / SECONDS_PER_DAY;
+    const midnightTimestamp = daysSinceEpoch * SECONDS_PER_DAY;
+
+    // Convert to i64 before multiplying by 1000 to avoid i32 overflow
+    const date = new Date(i64(midnightTimestamp) * 1000);
+    const year = date.getUTCFullYear();
+    const month = date.getUTCMonth() + 1;
+    const day = date.getUTCDate();
+
+    const monthStr = month < 10 ? '0' + month.toString() : month.toString();
+    const dayStr = day < 10 ? '0' + day.toString() : day.toString();
+
+    return year.toString() + '-' + monthStr + '-' + dayStr;
+}
+
+/**
+ * Gets the midnight UTC timestamp for a given block timestamp
+ */
+export function getMidnightTimestamp(timestamp: i32): i32 {
+    const SECONDS_PER_DAY = 86400;
+    const daysSinceEpoch = timestamp / SECONDS_PER_DAY;
+    return daysSinceEpoch * SECONDS_PER_DAY;
+}
+
+/**
+ * Upserts a DailyAccountUsage entity for the given account and timestamp
+ */
+export function upsertDailyAccountUsage(account: Account, timestamp: i32, blockNumber: BigInt): DailyAccountUsage {
+    const dateKey = getDateKey(timestamp);
+    const id = `DailyAccountUsage-${account.address}-${dateKey}`;
+
+    let dailyUsage = DailyAccountUsage.load(id);
+
+    if (!dailyUsage) {
+        dailyUsage = new DailyAccountUsage(id);
+        dailyUsage.date = dateKey;
+        dailyUsage.dateTimestamp = getMidnightTimestamp(timestamp);
+        dailyUsage.account = account.id;
+
+        dailyUsage.groupMessagesSent = BigInt.fromI32(0);
+        dailyUsage.groupMessageBytesSent = BigInt.fromI32(0);
+        dailyUsage.groupMessageFees = BigInt.fromI32(0);
+        dailyUsage.identityUpdatesCreated = BigInt.fromI32(0);
+        dailyUsage.identityUpdateBytesCreated = BigInt.fromI32(0);
+        dailyUsage.identityUpdateFees = BigInt.fromI32(0);
+        dailyUsage.depositsReceived = BigInt.fromI32(0);
+        dailyUsage.totalFees = BigInt.fromI32(0);
+        dailyUsage.eventCount = 0;
+    }
+
+    dailyUsage.lastUpdatedBlock = blockNumber;
+
+    return dailyUsage;
+}
+
+/**
+ * Upserts a DailyGlobalUsage entity for the given timestamp
+ */
+export function upsertDailyGlobalUsage(timestamp: i32, blockNumber: BigInt): DailyGlobalUsage {
+    const dateKey = getDateKey(timestamp);
+    const id = `DailyGlobalUsage-${dateKey}`;
+
+    let dailyUsage = DailyGlobalUsage.load(id);
+
+    if (!dailyUsage) {
+        dailyUsage = new DailyGlobalUsage(id);
+        dailyUsage.date = dateKey;
+        dailyUsage.dateTimestamp = getMidnightTimestamp(timestamp);
+
+        dailyUsage.totalGroupMessagesSent = BigInt.fromI32(0);
+        dailyUsage.totalGroupMessageBytesSent = BigInt.fromI32(0);
+        dailyUsage.totalGroupMessageFees = BigInt.fromI32(0);
+        dailyUsage.totalIdentityUpdatesCreated = BigInt.fromI32(0);
+        dailyUsage.totalIdentityUpdateBytesCreated = BigInt.fromI32(0);
+        dailyUsage.totalIdentityUpdateFees = BigInt.fromI32(0);
+        dailyUsage.totalDepositsReceived = BigInt.fromI32(0);
+        dailyUsage.totalWithdrawn = BigInt.fromI32(0);
+        dailyUsage.eventCount = 0;
+    }
+
+    dailyUsage.lastUpdatedBlock = blockNumber;
+
+    return dailyUsage;
 }

--- a/app-chain/src/group-message-broadcaster.ts
+++ b/app-chain/src/group-message-broadcaster.ts
@@ -27,7 +27,13 @@ import {
     Upgraded as UpgradedEvent,
 } from '../generated/GroupMessageBroadcaster/GroupMessageBroadcaster';
 
-import { ZERO_ADDRESS, getAccount, updateAccountFeesSnapshot } from './common';
+import {
+    ZERO_ADDRESS,
+    getAccount,
+    updateAccountFeesSnapshot,
+    upsertDailyAccountUsage,
+    upsertDailyGlobalUsage,
+} from './common';
 
 const STARTING_IMPLEMENTATION = dataSource.context().getString('startingImplementation');
 
@@ -54,6 +60,26 @@ export function handleMessageSent(event: MessageSentEvent): void {
 
     account.fees = account.fees.plus(transactionFee);
     updateAccountFeesSnapshot(account, timestamp, account.fees);
+
+    // Update daily time series
+    const dailyAccountUsage = upsertDailyAccountUsage(account, timestamp, event.block.number);
+    dailyAccountUsage.groupMessagesSent = dailyAccountUsage.groupMessagesSent.plus(BigInt.fromI32(1));
+    dailyAccountUsage.groupMessageBytesSent = dailyAccountUsage.groupMessageBytesSent.plus(
+        BigInt.fromI32(messageLength)
+    );
+    dailyAccountUsage.groupMessageFees = dailyAccountUsage.groupMessageFees.plus(transactionFee);
+    dailyAccountUsage.totalFees = dailyAccountUsage.totalFees.plus(transactionFee);
+    dailyAccountUsage.eventCount += 1;
+    dailyAccountUsage.save();
+
+    const dailyGlobalUsage = upsertDailyGlobalUsage(timestamp, event.block.number);
+    dailyGlobalUsage.totalGroupMessagesSent = dailyGlobalUsage.totalGroupMessagesSent.plus(BigInt.fromI32(1));
+    dailyGlobalUsage.totalGroupMessageBytesSent = dailyGlobalUsage.totalGroupMessageBytesSent.plus(
+        BigInt.fromI32(messageLength)
+    );
+    dailyGlobalUsage.totalGroupMessageFees = dailyGlobalUsage.totalGroupMessageFees.plus(transactionFee);
+    dailyGlobalUsage.eventCount += 1;
+    dailyGlobalUsage.save();
 
     account.lastUpdate = timestamp;
     account.save();

--- a/app-chain/src/identity-update-broadcaster.ts
+++ b/app-chain/src/identity-update-broadcaster.ts
@@ -27,7 +27,13 @@ import {
     Upgraded as UpgradedEvent,
 } from '../generated/IdentityUpdateBroadcaster/IdentityUpdateBroadcaster';
 
-import { ZERO_ADDRESS, getAccount, updateAccountFeesSnapshot } from './common';
+import {
+    ZERO_ADDRESS,
+    getAccount,
+    updateAccountFeesSnapshot,
+    upsertDailyAccountUsage,
+    upsertDailyGlobalUsage,
+} from './common';
 
 const STARTING_IMPLEMENTATION = dataSource.context().getString('startingImplementation');
 /* ============ Handlers ============ */
@@ -53,6 +59,26 @@ export function handleIdentityUpdateCreated(event: IdentityUpdateCreatedEvent): 
 
     account.fees = account.fees.plus(transactionFee);
     updateAccountFeesSnapshot(account, timestamp, account.fees);
+
+    // Update daily time series
+    const dailyAccountUsage = upsertDailyAccountUsage(account, timestamp, event.block.number);
+    dailyAccountUsage.identityUpdatesCreated = dailyAccountUsage.identityUpdatesCreated.plus(BigInt.fromI32(1));
+    dailyAccountUsage.identityUpdateBytesCreated = dailyAccountUsage.identityUpdateBytesCreated.plus(
+        BigInt.fromI32(updateLength)
+    );
+    dailyAccountUsage.identityUpdateFees = dailyAccountUsage.identityUpdateFees.plus(transactionFee);
+    dailyAccountUsage.totalFees = dailyAccountUsage.totalFees.plus(transactionFee);
+    dailyAccountUsage.eventCount += 1;
+    dailyAccountUsage.save();
+
+    const dailyGlobalUsage = upsertDailyGlobalUsage(timestamp, event.block.number);
+    dailyGlobalUsage.totalIdentityUpdatesCreated = dailyGlobalUsage.totalIdentityUpdatesCreated.plus(BigInt.fromI32(1));
+    dailyGlobalUsage.totalIdentityUpdateBytesCreated = dailyGlobalUsage.totalIdentityUpdateBytesCreated.plus(
+        BigInt.fromI32(updateLength)
+    );
+    dailyGlobalUsage.totalIdentityUpdateFees = dailyGlobalUsage.totalIdentityUpdateFees.plus(transactionFee);
+    dailyGlobalUsage.eventCount += 1;
+    dailyGlobalUsage.save();
 
     account.lastUpdate = timestamp;
     account.save();

--- a/app-chain/yarn.lock
+++ b/app-chain/yarn.lock
@@ -43,6 +43,16 @@
     graphql-import-node "^0.0.5"
     js-yaml "^4.1.0"
 
+"@goldskycom/cli@^3.1.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@goldskycom/cli/-/cli-3.2.0.tgz#9776f01a34f1c1c867dd6acdd12fd3695a543659"
+  integrity sha512-0ZTpE75rnfI0z0sZFvVpk9/i4dP7gWs/z4jQMcqWd6oPN+zofnuE/C18fIjOCmVm463wP6UN5kcnhpqC3fmMyg==
+  dependencies:
+    cuid "^2.1.8"
+    parse-duration "^1.0.3"
+    readline-sync "^1.4.10"
+    update-notifier "^6.0.2"
+
 "@graphprotocol/graph-cli@^0.97.1":
   version "0.97.1"
   resolved "https://registry.yarnpkg.com/@graphprotocol/graph-cli/-/graph-cli-0.97.1.tgz#a9130b813437b032aaf7857f2d75fc9f7c18f991"
@@ -533,6 +543,18 @@
     "@noble/hashes" "~1.4.0"
     "@scure/base" "~1.1.6"
 
+"@sindresorhus/is@^5.2.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-5.6.0.tgz#41dd6093d34652cddb5d5bdeee04eafc33826668"
+  integrity sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==
+
+"@szmarczak/http-timer@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-5.0.1.tgz#c7c1bf1141cdd4751b0399c8fc7b8b664cd5be3a"
+  integrity sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==
+  dependencies:
+    defer-to-connect "^2.0.1"
+
 "@types/connect@^3.4.33":
   version "3.4.38"
   resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.38.tgz#5ba7f3bc4fbbdeaff8dded952e5ff2cc53f8d858"
@@ -546,6 +568,11 @@
   integrity sha512-qXOC7XLOEe43ehtWJCMnQXvgcIpv6rPmQ1jXT98Ad8A3TB1Ue50jsCbSSSyuazScEuZ/Q026vHbrOTVkmwA+7Q==
   dependencies:
     "@types/node" "*"
+
+"@types/http-cache-semantics@^4.0.2":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz#b979ebad3919799c979b17c72621c0bc0a31c6c4"
+  integrity sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==
 
 "@types/node@*":
   version "24.3.0"
@@ -613,6 +640,13 @@ abort-error@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/abort-error/-/abort-error-1.0.1.tgz#526c17caf2ac9eb1fab1ffdff18c5076157a324e"
   integrity sha512-fxqCblJiIPdSXIUrxI0PL+eJG49QdP9SQ70qtB65MVAoMr2rASlOyAbJFOylfB467F/f+5BCLJJq58RYi7mGfg==
+
+ansi-align@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-3.0.1.tgz#0cdf12e111ace773a86e9a1fad1225c43cb19a59"
+  integrity sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==
+  dependencies:
+    string-width "^4.1.0"
 
 ansi-colors@^4.1.1:
   version "4.1.3"
@@ -755,6 +789,20 @@ blob-to-it@^2.0.5:
   dependencies:
     browser-readablestream-to-it "^2.0.0"
 
+boxen@^7.0.0:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/boxen/-/boxen-7.1.1.tgz#f9ba525413c2fec9cdb88987d835c4f7cad9c8f4"
+  integrity sha512-2hCgjEmP8YLWQ130n2FerGv7rYpfBmnmp9Uy2Le1vge6X3gZIfSmEzP5QTDElFxcvVcXlEn8Aq6MU/PZygIOog==
+  dependencies:
+    ansi-align "^3.0.1"
+    camelcase "^7.0.1"
+    chalk "^5.2.0"
+    cli-boxes "^3.0.0"
+    string-width "^5.1.2"
+    type-fest "^2.13.0"
+    widest-line "^4.0.1"
+    wrap-ansi "^8.1.0"
+
 brace-expansion@^1.1.7:
   version "1.1.12"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.12.tgz#ab9b454466e5a8cc3a187beaad580412a9c5b843"
@@ -802,6 +850,24 @@ bundle-name@^4.1.0:
   dependencies:
     run-applescript "^7.0.0"
 
+cacheable-lookup@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz#3476a8215d046e5a3202a9209dd13fec1f933a27"
+  integrity sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==
+
+cacheable-request@^10.2.8:
+  version "10.2.14"
+  resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-10.2.14.tgz#eb915b665fda41b79652782df3f553449c406b9d"
+  integrity sha512-zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==
+  dependencies:
+    "@types/http-cache-semantics" "^4.0.2"
+    get-stream "^6.0.1"
+    http-cache-semantics "^4.1.1"
+    keyv "^4.5.3"
+    mimic-response "^4.0.0"
+    normalize-url "^8.0.0"
+    responselike "^3.0.0"
+
 call-bind-apply-helpers@^1.0.0, call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz#4b5428c222be985d79c3d82657479dbe0b59b2d6"
@@ -833,6 +899,11 @@ callsites@^3.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
+camelcase@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-7.0.1.tgz#f02e50af9fd7782bc8b88a3558c32fd3a388f048"
+  integrity sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==
+
 cborg@^4.0.0:
   version "4.2.13"
   resolved "https://registry.yarnpkg.com/cborg/-/cborg-4.2.13.tgz#81eeae1437a770b1b40dc94d2f30a943cdb7fcd9"
@@ -847,6 +918,11 @@ chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+chalk@^5.0.1, chalk@^5.2.0:
+  version "5.6.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.6.2.tgz#b1238b6e23ea337af71c7f8a295db5af0c158aea"
+  integrity sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==
+
 chardet@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-2.1.0.tgz#1007f441a1ae9f9199a4a67f6e978fb0aa9aa3fe"
@@ -859,12 +935,22 @@ chokidar@4.0.3:
   dependencies:
     readdirp "^4.0.1"
 
+ci-info@^3.2.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.9.0.tgz#4279a62028a7b1f262f3473fc9605f5e218c59b4"
+  integrity sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==
+
 clean-stack@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-3.0.1.tgz#155bf0b2221bf5f4fba89528d24c5953f17fe3a8"
   integrity sha512-lR9wNiMRcVQjSB3a7xXGLuz4cr4wJuuXlaAEbRutGowQTmlp7R72/DOgN21e8jdwblMWl9UOJMJXarX94pzKdg==
   dependencies:
     escape-string-regexp "4.0.0"
+
+cli-boxes@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-3.0.0.tgz#71a10c716feeba005e4504f36329ef0b17cf3145"
+  integrity sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==
 
 cli-cursor@^3.1.0:
   version "3.1.0"
@@ -945,6 +1031,17 @@ config-chain@^1.1.11:
     ini "^1.3.4"
     proto-list "~1.2.1"
 
+configstore@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/configstore/-/configstore-6.0.0.tgz#49eca2ebc80983f77e09394a1a56e0aca8235566"
+  integrity sha512-cD31W1v3GqUlQvbBCGcXmd2Nj9SvLDOP1oQ0YFuLETufzSPaKp11rYBsSOm7rCsW3OnIRAFM3OxRhceaXNYHkA==
+  dependencies:
+    dot-prop "^6.0.1"
+    graceful-fs "^4.2.6"
+    unique-string "^3.0.0"
+    write-file-atomic "^3.0.3"
+    xdg-basedir "^5.0.1"
+
 content-type@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.5.tgz#8b773162656d1d1086784c8f23a54ce6d73d7918"
@@ -979,6 +1076,18 @@ cross-spawn@^7.0.3, cross-spawn@^7.0.6:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+crypto-random-string@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-4.0.0.tgz#5a3cc53d7dd86183df5da0312816ceeeb5bb1fc2"
+  integrity sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==
+  dependencies:
+    type-fest "^1.0.1"
+
+cuid@^2.1.8:
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/cuid/-/cuid-2.1.8.tgz#cbb88f954171e0d5747606c0139fb65c5101eac0"
+  integrity sha512-xiEMER6E7TlTPnDxrM4eRiC6TRgjNX9xzEZ5U/Se2YJKr7Mq4pJn/2XEHjl3STcSh96GmkHPcBXLES8M29wyyg==
+
 dag-jose@^5.0.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/dag-jose/-/dag-jose-5.1.1.tgz#02708321f14b6f43990e238010c73464916259a7"
@@ -993,6 +1102,18 @@ debug@4.4.1, debug@^4.1.1, debug@^4.4.0, debug@^4.4.1:
   integrity sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==
   dependencies:
     ms "^2.1.3"
+
+decompress-response@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-6.0.0.tgz#ca387612ddb7e104bd16d85aab00d5ecf09c66fc"
+  integrity sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==
+  dependencies:
+    mimic-response "^3.1.0"
+
+deep-extend@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
+  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 default-browser-id@^5.0.0:
   version "5.0.0"
@@ -1013,6 +1134,11 @@ defaults@^1.0.3:
   integrity sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==
   dependencies:
     clone "^1.0.2"
+
+defer-to-connect@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-2.0.1.tgz#8016bdb4143e4632b77a3449c6236277de520587"
+  integrity sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==
 
 define-data-property@^1.1.4:
   version "1.1.4"
@@ -1053,6 +1179,13 @@ docker-compose@1.2.0:
   integrity sha512-wIU1eHk3Op7dFgELRdmOYlPYS4gP8HhH1ZmZa13QZF59y0fblzFDFmKPhyc05phCy2hze9OEvNZAsoljrs+72w==
   dependencies:
     yaml "^2.2.2"
+
+dot-prop@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-6.0.1.tgz#fc26b3cf142b9e59b74dbd39ed66ce620c681083"
+  integrity sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==
+  dependencies:
+    is-obj "^2.0.0"
 
 dotenv@^16.5.0:
   version "16.6.1"
@@ -1158,6 +1291,11 @@ es6-promisify@^5.0.0:
   integrity sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==
   dependencies:
     es6-promise "^4.0.3"
+
+escape-goat@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/escape-goat/-/escape-goat-4.0.0.tgz#9424820331b510b0666b98f7873fe11ac4aa8081"
+  integrity sha512-2Sd4ShcWxbx6OY1IHyla/CVNwvg7XwZVoXZHcSu9w9SReNP1EzzD5T8NWKIR38fIqEns9kDWKUQTXXAmlDrdPg==
 
 escape-string-regexp@4.0.0:
   version "4.0.0"
@@ -1278,6 +1416,11 @@ foreground-child@^3.1.0:
     cross-spawn "^7.0.6"
     signal-exit "^4.0.1"
 
+form-data-encoder@^2.1.2:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/form-data-encoder/-/form-data-encoder-2.1.4.tgz#261ea35d2a70d48d30ec7a9603130fa5515e9cd5"
+  integrity sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==
+
 fs-extra@11.3.0:
   version "11.3.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.3.0.tgz#0daced136bbaf65a555a326719af931adc7a314d"
@@ -1339,7 +1482,7 @@ get-proto@^1.0.0, get-proto@^1.0.1:
     dunder-proto "^1.0.1"
     es-object-atoms "^1.0.0"
 
-get-stream@^6.0.0:
+get-stream@^6.0.0, get-stream@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
@@ -1374,6 +1517,13 @@ glob@^7.1.3:
     minimatch "^3.1.1"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+global-dirs@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-3.0.1.tgz#0c488971f066baceda21447aecb1a8b911d22485"
+  integrity sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==
+  dependencies:
+    ini "2.0.0"
 
 globby@^11.1.0:
   version "11.1.0"
@@ -1428,12 +1578,29 @@ gopd@^1.0.1, gopd@^1.2.0:
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
   integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
 
+got@^12.1.0:
+  version "12.6.1"
+  resolved "https://registry.yarnpkg.com/got/-/got-12.6.1.tgz#8869560d1383353204b5a9435f782df9c091f549"
+  integrity sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ==
+  dependencies:
+    "@sindresorhus/is" "^5.2.0"
+    "@szmarczak/http-timer" "^5.0.1"
+    cacheable-lookup "^7.0.0"
+    cacheable-request "^10.2.8"
+    decompress-response "^6.0.0"
+    form-data-encoder "^2.1.2"
+    get-stream "^6.0.1"
+    http2-wrapper "^2.1.10"
+    lowercase-keys "^3.0.0"
+    p-cancelable "^3.0.0"
+    responselike "^3.0.0"
+
 graceful-fs@4.2.10:
   version "4.2.10"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
-graceful-fs@^4.1.6, graceful-fs@^4.2.0:
+graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.6:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
@@ -1477,6 +1644,11 @@ has-tostringtag@^1.0.2:
   dependencies:
     has-symbols "^1.0.3"
 
+has-yarn@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-yarn/-/has-yarn-3.0.0.tgz#c3c21e559730d1d3b57e28af1f30d06fac38147d"
+  integrity sha512-IrsVwUHhEULx3R8f/aA8AHuEzAorplsab/v8HBzEiIukwq5i/EC+xmOW+HfP1OaDP+2JkgT1yILHN2O3UFIbcA==
+
 hashlru@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/hashlru/-/hashlru-2.3.0.tgz#5dc15928b3f6961a2056416bb3a4910216fdfb51"
@@ -1489,6 +1661,11 @@ hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
+http-cache-semantics@^4.1.1:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz#205f4db64f8562b76a4ff9235aa5279839a09dd5"
+  integrity sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==
+
 http-call@^5.2.2:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/http-call/-/http-call-5.3.0.tgz#4ded815b13f423de176eb0942d69c43b25b148db"
@@ -1500,6 +1677,14 @@ http-call@^5.2.2:
     is-stream "^2.0.0"
     parse-json "^4.0.0"
     tunnel-agent "^0.6.0"
+
+http2-wrapper@^2.1.10:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/http2-wrapper/-/http2-wrapper-2.2.1.tgz#310968153dcdedb160d8b72114363ef5fce1f64a"
+  integrity sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==
+  dependencies:
+    quick-lru "^5.1.1"
+    resolve-alpn "^1.2.0"
 
 human-signals@^2.1.0:
   version "2.1.0"
@@ -1536,6 +1721,16 @@ import-fresh@^3.2.1:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
 
+import-lazy@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-4.0.0.tgz#e8eb627483a0a43da3c03f3e35548be5cb0cc153"
+  integrity sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==
+
+imurmurhash@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
+  integrity sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
+
 indent-string@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
@@ -1554,7 +1749,12 @@ inherits@2, inherits@^2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
-ini@^1.3.4:
+ini@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-2.0.0.tgz#e5fd556ecdd5726be978fa1001862eacb0a94bc5"
+  integrity sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==
+
+ini@^1.3.4, ini@~1.3.0:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
@@ -1597,6 +1797,13 @@ is-callable@^1.2.7:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.7.tgz#3bc2a85ea742d9e36205dcacdd72ca1fdc51b055"
   integrity sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==
+
+is-ci@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-3.0.1.tgz#db6ecbed1bd659c43dac0f45661e7674103d1867"
+  integrity sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==
+  dependencies:
+    ci-info "^3.2.0"
 
 is-docker@^2.0.0:
   version "2.2.1"
@@ -1647,15 +1854,38 @@ is-inside-container@^1.0.0:
   dependencies:
     is-docker "^3.0.0"
 
+is-installed-globally@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.4.0.tgz#9a0fd407949c30f86eb6959ef1b7994ed0b7b520"
+  integrity sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==
+  dependencies:
+    global-dirs "^3.0.0"
+    is-path-inside "^3.0.2"
+
 is-interactive@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-interactive/-/is-interactive-1.0.0.tgz#cea6e6ae5c870a7b0a0004070b7b587e0252912e"
   integrity sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==
 
+is-npm@^6.0.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-6.1.0.tgz#f70e0b6c132dfc817ac97d3badc0134945b098d3"
+  integrity sha512-O2z4/kNgyjhQwVR1Wpkbfc19JIhggF97NZNCpWTnjH7kVcZMUrnut9XSN7txI7VdyIYk5ZatOq3zvSuWpU8hoA==
+
 is-number@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
+
+is-obj@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-2.0.0.tgz#473fb05d973705e3fd9620545018ca8e22ef4982"
+  integrity sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==
+
+is-path-inside@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.3.tgz#d231362e53a07ff2b0e0ea7fed049161ffd16283"
+  integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
 
 is-plain-obj@^2.1.0:
   version "2.1.0"
@@ -1689,6 +1919,11 @@ is-typed-array@^1.1.3:
   dependencies:
     which-typed-array "^1.1.16"
 
+is-typedarray@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
+  integrity sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==
+
 is-wsl@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
@@ -1702,6 +1937,11 @@ is-wsl@^3.1.0:
   integrity sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==
   dependencies:
     is-inside-container "^1.0.0"
+
+is-yarn-global@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/is-yarn-global/-/is-yarn-global-0.4.1.tgz#b312d902b313f81e4eaf98b6361ba2b45cd694bb"
+  integrity sha512-/kppl+R+LO5VmhYSEWARUFjodS25D68gvj8W7z0I7OWhUla5xWu8KL6CtB2V0R6yqhnRgbcaREMr4EEM6htLPQ==
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -1822,6 +2062,11 @@ js-yaml@4.1.0, js-yaml@^4.1.0:
   dependencies:
     argparse "^2.0.1"
 
+json-buffer@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"
+  integrity sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==
+
 json-parse-better-errors@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
@@ -1845,6 +2090,13 @@ jsonfile@^6.0.1:
     universalify "^2.0.0"
   optionalDependencies:
     graceful-fs "^4.1.6"
+
+keyv@^4.5.3:
+  version "4.5.4"
+  resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.5.4.tgz#a879a99e29452f942439f2a405e3af8b31d4de93"
+  integrity sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==
+  dependencies:
+    json-buffer "3.0.1"
 
 kubo-rpc-client@^5.0.2:
   version "5.2.0"
@@ -1884,6 +2136,13 @@ kubo-rpc-client@^5.0.2:
     stream-to-it "^1.0.1"
     uint8arrays "^5.0.3"
     wherearewe "^2.0.1"
+
+latest-version@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-7.0.0.tgz#843201591ea81a4d404932eeb61240fe04e9e5da"
+  integrity sha512-KvNT4XqAMzdcL6ka6Tl3i2lYeFDgXNCuIX+xNx6ZMVR1dFq+idXd9FLKNMOIx0t9mJ9/HudyX4oZWXZQ0UJHeg==
+  dependencies:
+    package-json "^8.1.0"
 
 lilconfig@^3.1.3:
   version "3.1.3"
@@ -1987,6 +2246,11 @@ long@^5.2.0, long@^5.2.1:
   resolved "https://registry.yarnpkg.com/long/-/long-5.3.2.tgz#1d84463095999262d7d7b7f8bfd4a8cc55167f83"
   integrity sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==
 
+lowercase-keys@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-3.0.0.tgz#c5e7d442e37ead247ae9db117a9d0a467c89d4f2"
+  integrity sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==
+
 lru-cache@^11.0.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-11.1.0.tgz#afafb060607108132dbc1cf8ae661afb69486117"
@@ -2039,6 +2303,16 @@ mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
+mimic-response@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-3.1.0.tgz#2d1d59af9c1b129815accc2c46a022a5ce1fa3c9"
+  integrity sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
+
+mimic-response@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-4.0.0.tgz#35468b19e7c75d10f5165ea25e75a5ceea7cf70f"
+  integrity sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==
+
 minimatch@^10.0.0:
   version "10.0.3"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.0.3.tgz#cf7a0314a16c4d9ab73a7730a0e8e3c3502d47aa"
@@ -2066,6 +2340,11 @@ minimatch@^9.0.5:
   integrity sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==
   dependencies:
     brace-expansion "^2.0.1"
+
+minimist@^1.2.0:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
+  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
 minipass@^7.1.2:
   version "7.1.2"
@@ -2106,6 +2385,11 @@ native-fetch@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/native-fetch/-/native-fetch-4.0.2.tgz#75c8a44c5f3bb021713e5e24f2846750883e49af"
   integrity sha512-4QcVlKFtv2EYVS5MBgsGX5+NWKtbDbIECdUXDBGDMAZXq3Jkv9zf+y8iS7Ub8fEdga3GpYeazp9gauNqXHJOCg==
+
+normalize-url@^8.0.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-8.1.0.tgz#d33504f67970decf612946fd4880bc8c0983486d"
+  integrity sha512-X06Mfd/5aKsRHc0O0J5CUedwnPmnDtLF2+nq+KN9KSDlJHkPuh0JUviWjEWMe0SW/9TDdSLVPuk7L5gGTIA1/w==
 
 npm-run-path@^4.0.1:
   version "4.0.1"
@@ -2156,6 +2440,11 @@ ora@4.0.2:
     strip-ansi "^5.2.0"
     wcwidth "^1.0.1"
 
+p-cancelable@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-3.0.0.tgz#63826694b54d61ca1c20ebcb6d3ecf5e14cd8050"
+  integrity sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==
+
 p-defer@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-3.0.0.tgz#d1dceb4ee9b2b604b1d94ffec83760175d4e6f83"
@@ -2192,12 +2481,27 @@ package-json-from-dist@^1.0.0:
   resolved "https://registry.yarnpkg.com/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz#4f1471a010827a86f94cfd9b0727e36d267de505"
   integrity sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==
 
+package-json@^8.1.0:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/package-json/-/package-json-8.1.1.tgz#3e9948e43df40d1e8e78a85485f1070bf8f03dc8"
+  integrity sha512-cbH9IAIJHNj9uXi196JVsRlt7cHKak6u/e6AkL/bkRelZ7rlL3X1YKxsZwa36xipOEKAsdtmaG6aAJoM1fx2zA==
+  dependencies:
+    got "^12.1.0"
+    registry-auth-token "^5.0.1"
+    registry-url "^6.0.0"
+    semver "^7.3.7"
+
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
   integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
   dependencies:
     callsites "^3.0.0"
+
+parse-duration@^1.0.3:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/parse-duration/-/parse-duration-1.1.2.tgz#20008e6c507814761864669bb936e3f4a9a80758"
+  integrity sha512-p8EIONG8L0u7f8GFgfVlL4n8rnChTt8O5FSxgxMz2tjc9FMP199wxVKVB6IbKx11uTbKHACSvaLVIKNnoeNR/A==
 
 parse-duration@^2.1.2:
   version "2.1.4"
@@ -2299,10 +2603,32 @@ protons-runtime@^5.5.0:
     uint8arraylist "^2.4.3"
     uint8arrays "^5.0.1"
 
+pupa@^3.1.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/pupa/-/pupa-3.3.0.tgz#bc4036f9e8920c08ad472bc18fb600067cb83810"
+  integrity sha512-LjgDO2zPtoXP2wJpDjZrGdojii1uqO0cnwKoIoUzkfS98HDmbeiGmYiXo3lXeFlq2xvne1QFQhwYXSUCLKtEuA==
+  dependencies:
+    escape-goat "^4.0.0"
+
 queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
+
+quick-lru@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
+  integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
+
+rc@1.2.8:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
+  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
+  dependencies:
+    deep-extend "^0.6.0"
+    ini "~1.3.0"
+    minimist "^1.2.0"
+    strip-json-comments "~2.0.1"
 
 react-native-fetch-api@^3.0.0:
   version "3.0.0"
@@ -2325,17 +2651,41 @@ readdirp@^4.0.1:
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-4.1.2.tgz#eb85801435fbf2a7ee58f19e0921b068fc69948d"
   integrity sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==
 
-registry-auth-token@^5.1.0:
+readline-sync@^1.4.10:
+  version "1.4.10"
+  resolved "https://registry.yarnpkg.com/readline-sync/-/readline-sync-1.4.10.tgz#41df7fbb4b6312d673011594145705bf56d8873b"
+  integrity sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==
+
+registry-auth-token@^5.0.1, registry-auth-token@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-5.1.0.tgz#3c659047ecd4caebd25bc1570a3aa979ae490eca"
   integrity sha512-GdekYuwLXLxMuFTwAPg5UKGLW/UXzQrZvH/Zj791BQif5T05T0RsaLfHc9q3ZOKi7n+BoprPD9mJ0O0k4xzUlw==
   dependencies:
     "@pnpm/npm-conf" "^2.1.0"
 
+registry-url@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/registry-url/-/registry-url-6.0.1.tgz#056d9343680f2f64400032b1e199faa692286c58"
+  integrity sha512-+crtS5QjFRqFCoQmvGduwYWEBng99ZvmFvF+cUJkGYF1L1BfU8C6Zp9T7f5vPAwyLkUExpvK+ANVZmGU49qi4Q==
+  dependencies:
+    rc "1.2.8"
+
+resolve-alpn@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/resolve-alpn/-/resolve-alpn-1.2.1.tgz#b7adbdac3546aaaec20b45e7d8265927072726f9"
+  integrity sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==
+
 resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
+
+responselike@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/responselike/-/responselike-3.0.0.tgz#20decb6c298aff0dbee1c355ca95461d42823626"
+  integrity sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==
+  dependencies:
+    lowercase-keys "^3.0.0"
 
 restore-cursor@^3.1.0:
   version "3.1.0"
@@ -2388,6 +2738,13 @@ safe-regex-test@^1.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
+semver-diff@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/semver-diff/-/semver-diff-4.0.0.tgz#3afcf5ed6d62259f5c72d0d5d50dffbdc9680df5"
+  integrity sha512-0Ju4+6A8iOnpL/Thra7dZsSlOHYAHIeMxfhWQRI1/VLcT3WDBZKKtQt/QkBOsiIN9ZpuvHE6cGZ0x4glCMmfiA==
+  dependencies:
+    semver "^7.3.5"
+
 semver@7.3.5:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
@@ -2399,6 +2756,11 @@ semver@7.7.2, semver@^7.6.3:
   version "7.7.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.2.tgz#67d99fdcd35cec21e6f8b87a7fd515a33f982b58"
   integrity sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==
+
+semver@^7.3.5, semver@^7.3.7:
+  version "7.7.3"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.3.tgz#4b5f4143d007633a8dc671cd0a6ef9147b8bb946"
+  integrity sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==
 
 set-function-length@^1.2.2:
   version "1.2.2"
@@ -2471,16 +2833,7 @@ stream-to-it@^1.0.1:
   dependencies:
     it-stream-types "^2.0.1"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -2505,7 +2858,7 @@ string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.2.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -2519,13 +2872,6 @@ strip-ansi@^5.2.0:
   dependencies:
     ansi-regex "^4.1.0"
 
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
 strip-ansi@^7.0.1:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.1.0.tgz#d5b6568ca689d8561370b0707685d22434faff45"
@@ -2537,6 +2883,11 @@ strip-final-newline@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
+
+strip-json-comments@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
+  integrity sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==
 
 supports-color@^5.3.0:
   version "5.5.0"
@@ -2601,6 +2952,23 @@ type-fest@^0.21.3:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
+type-fest@^1.0.1:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.4.0.tgz#e9fb813fe3bf1744ec359d55d1affefa76f14be1"
+  integrity sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==
+
+type-fest@^2.13.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.19.0.tgz#88068015bb33036a598b952e55e9311a60fd3a9b"
+  integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
+
+typedarray-to-buffer@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
+  integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
+  dependencies:
+    is-typedarray "^1.0.0"
+
 uint8-varint@^2.0.1, uint8-varint@^2.0.2:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/uint8-varint/-/uint8-varint-2.0.4.tgz#85be52b3849eb30f2c3640a2df8a14364180affb"
@@ -2633,10 +3001,37 @@ undici@7.9.0:
   resolved "https://registry.yarnpkg.com/undici/-/undici-7.9.0.tgz#09266190e9281cb049ba79ca6a5ec9372175dfd9"
   integrity sha512-e696y354tf5cFZPXsF26Yg+5M63+5H3oE6Vtkh2oqbvsE2Oe7s2nIbcQh5lmG7Lp/eS29vJtTpw9+p6PX0qNSg==
 
+unique-string@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-3.0.0.tgz#84a1c377aff5fd7a8bc6b55d8244b2bd90d75b9a"
+  integrity sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==
+  dependencies:
+    crypto-random-string "^4.0.0"
+
 universalify@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.1.tgz#168efc2180964e6386d061e094df61afe239b18d"
   integrity sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==
+
+update-notifier@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-6.0.2.tgz#a6990253dfe6d5a02bd04fbb6a61543f55026b60"
+  integrity sha512-EDxhTEVPZZRLWYcJ4ZXjGFN0oP7qYvbXWzEgRm/Yql4dHX5wDbvh89YHP6PK1lzZJYrMtXUuZZz8XGK+U6U1og==
+  dependencies:
+    boxen "^7.0.0"
+    chalk "^5.0.1"
+    configstore "^6.0.0"
+    has-yarn "^3.0.0"
+    import-lazy "^4.0.0"
+    is-ci "^3.0.1"
+    is-installed-globally "^0.4.0"
+    is-npm "^6.0.0"
+    is-yarn-global "^0.4.0"
+    latest-version "^7.0.0"
+    pupa "^3.1.0"
+    semver "^7.3.7"
+    semver-diff "^4.0.0"
+    xdg-basedir "^5.1.0"
 
 urlpattern-polyfill@^10.0.0:
   version "10.1.0"
@@ -2758,12 +3153,19 @@ widest-line@^3.1.0:
   dependencies:
     string-width "^4.0.0"
 
+widest-line@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/widest-line/-/widest-line-4.0.1.tgz#a0fc673aaba1ea6f0a0d35b3c2795c9a9cc2ebf2"
+  integrity sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==
+  dependencies:
+    string-width "^5.0.1"
+
 wordwrap@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -2776,15 +3178,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
@@ -2804,10 +3197,25 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
+write-file-atomic@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-3.0.3.tgz#56bd5c5a5c70481cd19c571bd39ab965a5de56e8"
+  integrity sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==
+  dependencies:
+    imurmurhash "^0.1.4"
+    is-typedarray "^1.0.0"
+    signal-exit "^3.0.2"
+    typedarray-to-buffer "^3.1.5"
+
 ws@^7.5.10:
   version "7.5.10"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.10.tgz#58b5c20dc281633f6c19113f39b349bd8bd558d9"
   integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
+
+xdg-basedir@^5.0.1, xdg-basedir@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-5.1.0.tgz#1efba19425e73be1bc6f2a6ceb52a3d2c884c0c9"
+  integrity sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==
 
 yallist@^4.0.0:
   version "4.0.0"

--- a/settlement-chain/abis/DistributionManager.abi.json
+++ b/settlement-chain/abis/DistributionManager.abi.json
@@ -1,316 +1,737 @@
 [
-    {
-        "type": "constructor",
-        "inputs": [
-            { "name": "parameterRegistry_", "type": "address", "internalType": "address" },
-            { "name": "nodeRegistry_", "type": "address", "internalType": "address" },
-            { "name": "payerReportManager_", "type": "address", "internalType": "address" },
-            { "name": "payerRegistry_", "type": "address", "internalType": "address" },
-            { "name": "feeToken_", "type": "address", "internalType": "address" }
-        ],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "areFeesClaimed",
-        "inputs": [
-            { "name": "nodeId_", "type": "uint32", "internalType": "uint32" },
-            { "name": "originatorNodeId_", "type": "uint32", "internalType": "uint32" },
-            { "name": "payerReportIndex_", "type": "uint256", "internalType": "uint256" }
-        ],
-        "outputs": [{ "name": "hasClaimed_", "type": "bool", "internalType": "bool" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "areProtocolFeesClaimed",
-        "inputs": [
-            { "name": "originatorNodeId_", "type": "uint32", "internalType": "uint32" },
-            { "name": "payerReportIndex_", "type": "uint256", "internalType": "uint256" }
-        ],
-        "outputs": [{ "name": "areClaimed_", "type": "bool", "internalType": "bool" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "claim",
-        "inputs": [
-            { "name": "nodeId_", "type": "uint32", "internalType": "uint32" },
-            { "name": "originatorNodeIds_", "type": "uint32[]", "internalType": "uint32[]" },
-            { "name": "payerReportIndices_", "type": "uint256[]", "internalType": "uint256[]" }
-        ],
-        "outputs": [{ "name": "claimed_", "type": "uint96", "internalType": "uint96" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "claimProtocolFees",
-        "inputs": [
-            { "name": "originatorNodeIds_", "type": "uint32[]", "internalType": "uint32[]" },
-            { "name": "payerReportIndices_", "type": "uint256[]", "internalType": "uint256[]" }
-        ],
-        "outputs": [{ "name": "claimed_", "type": "uint96", "internalType": "uint96" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "feeToken",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "getOwedFees",
-        "inputs": [{ "name": "nodeId_", "type": "uint32", "internalType": "uint32" }],
-        "outputs": [{ "name": "owedFees_", "type": "uint96", "internalType": "uint96" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "implementation",
-        "inputs": [],
-        "outputs": [{ "name": "implementation_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    { "type": "function", "name": "initialize", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    { "type": "function", "name": "migrate", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "migratorParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "nodeRegistry",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "owedProtocolFees",
-        "inputs": [],
-        "outputs": [{ "name": "owedProtocolFees_", "type": "uint96", "internalType": "uint96" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "parameterRegistry",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "parameterRegistry_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "nodeRegistry_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "payerReportManager_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "payerRegistry_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "feeToken_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "areFeesClaimed",
+    "inputs": [
+      {
+        "name": "nodeId_",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "originatorNodeId_",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "payerReportIndex_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "hasClaimed_",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "areProtocolFeesClaimed",
+    "inputs": [
+      {
+        "name": "originatorNodeId_",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "payerReportIndex_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "areClaimed_",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "claim",
+    "inputs": [
+      {
+        "name": "nodeId_",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "originatorNodeIds_",
+        "type": "uint32[]",
+        "internalType": "uint32[]"
+      },
+      {
+        "name": "payerReportIndices_",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "claimed_",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "claimProtocolFees",
+    "inputs": [
+      {
+        "name": "originatorNodeIds_",
+        "type": "uint32[]",
+        "internalType": "uint32[]"
+      },
+      {
+        "name": "payerReportIndices_",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "claimed_",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "feeToken",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getOwedFees",
+    "inputs": [
+      {
+        "name": "nodeId_",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "owedFees_",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "implementation",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "implementation_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "migrate",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "migratorParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "nodeRegistry",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "owedProtocolFees",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "owedProtocolFees_",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "parameterRegistry",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "paused",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "paused_",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "pausedParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "payerRegistry",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "payerReportManager",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "protocolFeesRecipient",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "protocolFeesRecipient_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "protocolFeesRecipientParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "totalOwedFees",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "totalOwedFees_",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "updatePauseStatus",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateProtocolFeesRecipient",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "withdraw",
+    "inputs": [
+      {
+        "name": "nodeId_",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "recipient_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "withdrawn_",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "withdrawIntoUnderlying",
+    "inputs": [
+      {
+        "name": "nodeId_",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "recipient_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "withdrawn_",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "withdrawProtocolFees",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "withdrawn_",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "withdrawProtocolFeesIntoUnderlying",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "withdrawn_",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "Claim",
+    "inputs": [
+      {
+        "name": "nodeId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "originatorNodeId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "payerReportIndex",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "amount",
+        "type": "uint96",
+        "indexed": false,
+        "internalType": "uint96"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Migrated",
+    "inputs": [
+      {
+        "name": "migrator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PauseStatusUpdated",
+    "inputs": [
+      {
         "name": "paused",
-        "inputs": [],
-        "outputs": [{ "name": "paused_", "type": "bool", "internalType": "bool" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "pausedParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "payerRegistry",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "payerReportManager",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
+        "type": "bool",
+        "indexed": true,
+        "internalType": "bool"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ProtocolFeesClaim",
+    "inputs": [
+      {
+        "name": "originatorNodeId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "payerReportIndex",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "amount",
+        "type": "uint96",
+        "indexed": false,
+        "internalType": "uint96"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ProtocolFeesRecipientUpdated",
+    "inputs": [
+      {
         "name": "protocolFeesRecipient",
-        "inputs": [],
-        "outputs": [{ "name": "protocolFeesRecipient_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "protocolFeesRecipientParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "totalOwedFees",
-        "inputs": [],
-        "outputs": [{ "name": "totalOwedFees_", "type": "uint96", "internalType": "uint96" }],
-        "stateMutability": "view"
-    },
-    { "type": "function", "name": "updatePauseStatus", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "updateProtocolFeesRecipient",
-        "inputs": [],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "withdraw",
-        "inputs": [
-            { "name": "nodeId_", "type": "uint32", "internalType": "uint32" },
-            { "name": "recipient_", "type": "address", "internalType": "address" }
-        ],
-        "outputs": [{ "name": "withdrawn_", "type": "uint96", "internalType": "uint96" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "withdrawIntoUnderlying",
-        "inputs": [
-            { "name": "nodeId_", "type": "uint32", "internalType": "uint32" },
-            { "name": "recipient_", "type": "address", "internalType": "address" }
-        ],
-        "outputs": [{ "name": "withdrawn_", "type": "uint96", "internalType": "uint96" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "withdrawProtocolFees",
-        "inputs": [],
-        "outputs": [{ "name": "withdrawn_", "type": "uint96", "internalType": "uint96" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "withdrawProtocolFeesIntoUnderlying",
-        "inputs": [],
-        "outputs": [{ "name": "withdrawn_", "type": "uint96", "internalType": "uint96" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "event",
-        "name": "Claim",
-        "inputs": [
-            { "name": "nodeId", "type": "uint32", "indexed": true, "internalType": "uint32" },
-            { "name": "originatorNodeId", "type": "uint32", "indexed": true, "internalType": "uint32" },
-            { "name": "payerReportIndex", "type": "uint256", "indexed": true, "internalType": "uint256" },
-            { "name": "amount", "type": "uint96", "indexed": false, "internalType": "uint96" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Initialized",
-        "inputs": [{ "name": "version", "type": "uint64", "indexed": false, "internalType": "uint64" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Migrated",
-        "inputs": [{ "name": "migrator", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "PauseStatusUpdated",
-        "inputs": [{ "name": "paused", "type": "bool", "indexed": true, "internalType": "bool" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "ProtocolFeesClaim",
-        "inputs": [
-            { "name": "originatorNodeId", "type": "uint32", "indexed": true, "internalType": "uint32" },
-            { "name": "payerReportIndex", "type": "uint256", "indexed": true, "internalType": "uint256" },
-            { "name": "amount", "type": "uint96", "indexed": false, "internalType": "uint96" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "ProtocolFeesRecipientUpdated",
-        "inputs": [{ "name": "protocolFeesRecipient", "type": "address", "indexed": false, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "ProtocolFeesWithdrawal",
-        "inputs": [{ "name": "amount", "type": "uint96", "indexed": false, "internalType": "uint96" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Upgraded",
-        "inputs": [{ "name": "implementation", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Withdrawal",
-        "inputs": [
-            { "name": "nodeId", "type": "uint32", "indexed": true, "internalType": "uint32" },
-            { "name": "amount", "type": "uint96", "indexed": false, "internalType": "uint96" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "error",
-        "name": "AlreadyClaimed",
-        "inputs": [
-            { "name": "originatorNodeId", "type": "uint32", "internalType": "uint32" },
-            { "name": "payerReportIndex", "type": "uint256", "internalType": "uint256" }
-        ]
-    },
-    { "type": "error", "name": "ArrayLengthMismatch", "inputs": [] },
-    {
-        "type": "error",
-        "name": "EmptyCode",
-        "inputs": [{ "name": "migrator_", "type": "address", "internalType": "address" }]
-    },
-    { "type": "error", "name": "InvalidInitialization", "inputs": [] },
-    {
-        "type": "error",
-        "name": "MigrationFailed",
-        "inputs": [
-            { "name": "migrator_", "type": "address", "internalType": "address" },
-            { "name": "revertData_", "type": "bytes", "internalType": "bytes" }
-        ]
-    },
-    { "type": "error", "name": "NoChange", "inputs": [] },
-    { "type": "error", "name": "NoFeesOwed", "inputs": [] },
-    {
-        "type": "error",
-        "name": "NotInPayerReport",
-        "inputs": [
-            { "name": "originatorNodeId", "type": "uint32", "internalType": "uint32" },
-            { "name": "payerReportIndex", "type": "uint256", "internalType": "uint256" }
-        ]
-    },
-    { "type": "error", "name": "NotInitializing", "inputs": [] },
-    { "type": "error", "name": "NotNodeOwner", "inputs": [] },
-    { "type": "error", "name": "ParameterOutOfTypeBounds", "inputs": [] },
-    { "type": "error", "name": "Paused", "inputs": [] },
-    {
-        "type": "error",
-        "name": "PayerReportNotSettled",
-        "inputs": [
-            { "name": "originatorNodeId", "type": "uint32", "internalType": "uint32" },
-            { "name": "payerReportIndex", "type": "uint256", "internalType": "uint256" }
-        ]
-    },
-    { "type": "error", "name": "ZeroAvailableBalance", "inputs": [] },
-    { "type": "error", "name": "ZeroFeeToken", "inputs": [] },
-    { "type": "error", "name": "ZeroMigrator", "inputs": [] },
-    { "type": "error", "name": "ZeroNodeRegistry", "inputs": [] },
-    { "type": "error", "name": "ZeroParameterRegistry", "inputs": [] },
-    { "type": "error", "name": "ZeroPayerRegistry", "inputs": [] },
-    { "type": "error", "name": "ZeroPayerReportManager", "inputs": [] },
-    { "type": "error", "name": "ZeroRecipient", "inputs": [] }
+        "type": "address",
+        "indexed": false,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ProtocolFeesWithdrawal",
+    "inputs": [
+      {
+        "name": "amount",
+        "type": "uint96",
+        "indexed": false,
+        "internalType": "uint96"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Withdrawal",
+    "inputs": [
+      {
+        "name": "nodeId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "amount",
+        "type": "uint96",
+        "indexed": false,
+        "internalType": "uint96"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "AlreadyClaimed",
+    "inputs": [
+      {
+        "name": "originatorNodeId",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "payerReportIndex",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ArrayLengthMismatch",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "EmptyCode",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InvalidInitialization",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MigrationFailed",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "revertData_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "NoChange",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NoFeesOwed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotInPayerReport",
+    "inputs": [
+      {
+        "name": "originatorNodeId",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "payerReportIndex",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotNodeOwner",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ParameterOutOfTypeBounds",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Paused",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "PayerReportNotSettled",
+    "inputs": [
+      {
+        "name": "originatorNodeId",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "payerReportIndex",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ZeroAvailableBalance",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroFeeToken",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroMigrator",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroNodeRegistry",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroParameterRegistry",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroPayerRegistry",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroPayerReportManager",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroRecipient",
+    "inputs": []
+  }
 ]

--- a/settlement-chain/abis/Factory.abi.json
+++ b/settlement-chain/abis/Factory.abi.json
@@ -1,153 +1,376 @@
 [
-    {
-        "type": "constructor",
-        "inputs": [{ "name": "parameterRegistry_", "type": "address", "internalType": "address" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "computeImplementationAddress",
-        "inputs": [{ "name": "bytecode_", "type": "bytes", "internalType": "bytes" }],
-        "outputs": [{ "name": "implementation_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "computeProxyAddress",
-        "inputs": [
-            { "name": "caller_", "type": "address", "internalType": "address" },
-            { "name": "salt_", "type": "bytes32", "internalType": "bytes32" }
-        ],
-        "outputs": [{ "name": "proxy_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "deployImplementation",
-        "inputs": [{ "name": "bytecode_", "type": "bytes", "internalType": "bytes" }],
-        "outputs": [{ "name": "implementation_", "type": "address", "internalType": "address" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "deployProxy",
-        "inputs": [
-            { "name": "implementation_", "type": "address", "internalType": "address" },
-            { "name": "salt_", "type": "bytes32", "internalType": "bytes32" },
-            { "name": "initializeCallData_", "type": "bytes", "internalType": "bytes" }
-        ],
-        "outputs": [{ "name": "proxy_", "type": "address", "internalType": "address" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "parameterRegistry_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "computeImplementationAddress",
+    "inputs": [
+      {
+        "name": "bytecode_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "implementation_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "computeProxyAddress",
+    "inputs": [
+      {
+        "name": "caller_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "salt_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "proxy_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "deployImplementation",
+    "inputs": [
+      {
+        "name": "bytecode_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "implementation_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "deployProxy",
+    "inputs": [
+      {
+        "name": "implementation_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "salt_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "initializeCallData_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "proxy_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "implementation",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "implementation_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initializableImplementation",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "initializableImplementation_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "migrate",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "migratorParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "parameterRegistry",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "paused",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "paused_",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "pausedParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "event",
+    "name": "ImplementationDeployed",
+    "inputs": [
+      {
         "name": "implementation",
-        "inputs": [],
-        "outputs": [{ "name": "implementation_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "initializableImplementation",
-        "inputs": [],
-        "outputs": [{ "name": "initializableImplementation_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    { "type": "function", "name": "initialize", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    { "type": "function", "name": "migrate", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "migratorParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "parameterRegistry",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "paused",
-        "inputs": [],
-        "outputs": [{ "name": "paused_", "type": "bool", "internalType": "bool" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "pausedParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "event",
-        "name": "ImplementationDeployed",
-        "inputs": [
-            { "name": "implementation", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "bytecodeHash", "type": "bytes32", "indexed": true, "internalType": "bytes32" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "InitializableImplementationDeployed",
-        "inputs": [{ "name": "implementation", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Initialized",
-        "inputs": [{ "name": "version", "type": "uint64", "indexed": false, "internalType": "uint64" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Migrated",
-        "inputs": [{ "name": "migrator", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "ProxyDeployed",
-        "inputs": [
-            { "name": "proxy", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "implementation", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "sender", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "salt", "type": "bytes32", "indexed": false, "internalType": "bytes32" },
-            { "name": "initializeCallData", "type": "bytes", "indexed": false, "internalType": "bytes" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Upgraded",
-        "inputs": [{ "name": "implementation", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    { "type": "error", "name": "DeployFailed", "inputs": [] },
-    { "type": "error", "name": "EmptyBytecode", "inputs": [] },
-    {
-        "type": "error",
-        "name": "EmptyCode",
-        "inputs": [{ "name": "migrator_", "type": "address", "internalType": "address" }]
-    },
-    { "type": "error", "name": "InvalidImplementation", "inputs": [] },
-    { "type": "error", "name": "InvalidInitialization", "inputs": [] },
-    {
-        "type": "error",
-        "name": "MigrationFailed",
-        "inputs": [
-            { "name": "migrator_", "type": "address", "internalType": "address" },
-            { "name": "revertData_", "type": "bytes", "internalType": "bytes" }
-        ]
-    },
-    { "type": "error", "name": "NotInitializing", "inputs": [] },
-    { "type": "error", "name": "ParameterOutOfTypeBounds", "inputs": [] },
-    { "type": "error", "name": "Paused", "inputs": [] },
-    { "type": "error", "name": "ZeroMigrator", "inputs": [] },
-    { "type": "error", "name": "ZeroParameterRegistry", "inputs": [] }
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "bytecodeHash",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "InitializableImplementationDeployed",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Migrated",
+    "inputs": [
+      {
+        "name": "migrator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ProxyDeployed",
+    "inputs": [
+      {
+        "name": "proxy",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "sender",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "salt",
+        "type": "bytes32",
+        "indexed": false,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "initializeCallData",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "DeployFailed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "EmptyBytecode",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "EmptyCode",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InvalidImplementation",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidInitialization",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MigrationFailed",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "revertData_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ParameterOutOfTypeBounds",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Paused",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroMigrator",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroParameterRegistry",
+    "inputs": []
+  }
 ]

--- a/settlement-chain/abis/FeeToken.abi.json
+++ b/settlement-chain/abis/FeeToken.abi.json
@@ -1,373 +1,905 @@
 [
-    {
-        "type": "constructor",
-        "inputs": [
-            { "name": "parameterRegistry_", "type": "address", "internalType": "address" },
-            { "name": "underlying_", "type": "address", "internalType": "address" }
-        ],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "DOMAIN_SEPARATOR",
-        "inputs": [],
-        "outputs": [{ "name": "domainSeparator_", "type": "bytes32", "internalType": "bytes32" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "PERMIT_TYPEHASH",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "bytes32", "internalType": "bytes32" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "allowance",
-        "inputs": [
-            { "name": "owner", "type": "address", "internalType": "address" },
-            { "name": "spender", "type": "address", "internalType": "address" }
-        ],
-        "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "approve",
-        "inputs": [
-            { "name": "spender", "type": "address", "internalType": "address" },
-            { "name": "value", "type": "uint256", "internalType": "uint256" }
-        ],
-        "outputs": [{ "name": "", "type": "bool", "internalType": "bool" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "balanceOf",
-        "inputs": [{ "name": "account", "type": "address", "internalType": "address" }],
-        "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "decimals",
-        "inputs": [],
-        "outputs": [{ "name": "decimals_", "type": "uint8", "internalType": "uint8" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "deposit",
-        "inputs": [{ "name": "amount_", "type": "uint256", "internalType": "uint256" }],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "depositFor",
-        "inputs": [
-            { "name": "recipient_", "type": "address", "internalType": "address" },
-            { "name": "amount_", "type": "uint256", "internalType": "uint256" }
-        ],
-        "outputs": [{ "name": "success_", "type": "bool", "internalType": "bool" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "depositForWithPermit",
-        "inputs": [
-            { "name": "recipient_", "type": "address", "internalType": "address" },
-            { "name": "amount_", "type": "uint256", "internalType": "uint256" },
-            { "name": "deadline_", "type": "uint256", "internalType": "uint256" },
-            { "name": "v_", "type": "uint8", "internalType": "uint8" },
-            { "name": "r_", "type": "bytes32", "internalType": "bytes32" },
-            { "name": "s_", "type": "bytes32", "internalType": "bytes32" }
-        ],
-        "outputs": [{ "name": "success_", "type": "bool", "internalType": "bool" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "depositWithPermit",
-        "inputs": [
-            { "name": "amount_", "type": "uint256", "internalType": "uint256" },
-            { "name": "deadline_", "type": "uint256", "internalType": "uint256" },
-            { "name": "v_", "type": "uint8", "internalType": "uint8" },
-            { "name": "r_", "type": "bytes32", "internalType": "bytes32" },
-            { "name": "s_", "type": "bytes32", "internalType": "bytes32" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "eip712Domain",
-        "inputs": [],
-        "outputs": [
-            { "name": "fields", "type": "bytes1", "internalType": "bytes1" },
-            { "name": "name", "type": "string", "internalType": "string" },
-            { "name": "version", "type": "string", "internalType": "string" },
-            { "name": "chainId", "type": "uint256", "internalType": "uint256" },
-            { "name": "verifyingContract", "type": "address", "internalType": "address" },
-            { "name": "salt", "type": "bytes32", "internalType": "bytes32" },
-            { "name": "extensions", "type": "uint256[]", "internalType": "uint256[]" }
-        ],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "getPermitDigest",
-        "inputs": [
-            { "name": "owner_", "type": "address", "internalType": "address" },
-            { "name": "spender_", "type": "address", "internalType": "address" },
-            { "name": "value_", "type": "uint256", "internalType": "uint256" },
-            { "name": "nonce_", "type": "uint256", "internalType": "uint256" },
-            { "name": "deadline_", "type": "uint256", "internalType": "uint256" }
-        ],
-        "outputs": [{ "name": "digest_", "type": "bytes32", "internalType": "bytes32" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "implementation",
-        "inputs": [],
-        "outputs": [{ "name": "implementation_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    { "type": "function", "name": "initialize", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    { "type": "function", "name": "migrate", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "migratorParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "parameterRegistry_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "underlying_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "DOMAIN_SEPARATOR",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "domainSeparator_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "PERMIT_TYPEHASH",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "allowance",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "spender",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "approve",
+    "inputs": [
+      {
+        "name": "spender",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "balanceOf",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "decimals",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "decimals_",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "deposit",
+    "inputs": [
+      {
+        "name": "amount_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "depositFor",
+    "inputs": [
+      {
+        "name": "recipient_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "success_",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "depositForWithPermit",
+    "inputs": [
+      {
+        "name": "recipient_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "deadline_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "v_",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "r_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "s_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "success_",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "depositWithPermit",
+    "inputs": [
+      {
+        "name": "amount_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "deadline_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "v_",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "r_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "s_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "eip712Domain",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "fields",
+        "type": "bytes1",
+        "internalType": "bytes1"
+      },
+      {
         "name": "name",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "string", "internalType": "string" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "nonces",
-        "inputs": [{ "name": "owner_", "type": "address", "internalType": "address" }],
-        "outputs": [{ "name": "nonce_", "type": "uint256", "internalType": "uint256" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "parameterRegistry",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "permit",
-        "inputs": [
-            { "name": "owner_", "type": "address", "internalType": "address" },
-            { "name": "spender_", "type": "address", "internalType": "address" },
-            { "name": "value_", "type": "uint256", "internalType": "uint256" },
-            { "name": "deadline_", "type": "uint256", "internalType": "uint256" },
-            { "name": "v_", "type": "uint8", "internalType": "uint8" },
-            { "name": "r_", "type": "bytes32", "internalType": "bytes32" },
-            { "name": "s_", "type": "bytes32", "internalType": "bytes32" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "symbol",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "string", "internalType": "string" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "totalSupply",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "transfer",
-        "inputs": [
-            { "name": "to", "type": "address", "internalType": "address" },
-            { "name": "value", "type": "uint256", "internalType": "uint256" }
-        ],
-        "outputs": [{ "name": "", "type": "bool", "internalType": "bool" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "transferFrom",
-        "inputs": [
-            { "name": "from", "type": "address", "internalType": "address" },
-            { "name": "to", "type": "address", "internalType": "address" },
-            { "name": "value", "type": "uint256", "internalType": "uint256" }
-        ],
-        "outputs": [{ "name": "", "type": "bool", "internalType": "bool" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "underlying",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "withdraw",
-        "inputs": [{ "name": "amount_", "type": "uint256", "internalType": "uint256" }],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "withdrawTo",
-        "inputs": [
-            { "name": "recipient_", "type": "address", "internalType": "address" },
-            { "name": "amount_", "type": "uint256", "internalType": "uint256" }
-        ],
-        "outputs": [{ "name": "success_", "type": "bool", "internalType": "bool" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "event",
-        "name": "Approval",
-        "inputs": [
-            { "name": "owner", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "spender", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "value", "type": "uint256", "indexed": false, "internalType": "uint256" }
-        ],
-        "anonymous": false
-    },
-    { "type": "event", "name": "EIP712DomainChanged", "inputs": [], "anonymous": false },
-    {
-        "type": "event",
-        "name": "Initialized",
-        "inputs": [{ "name": "version", "type": "uint64", "indexed": false, "internalType": "uint64" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Migrated",
-        "inputs": [{ "name": "migrator", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Transfer",
-        "inputs": [
-            { "name": "from", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "to", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "value", "type": "uint256", "indexed": false, "internalType": "uint256" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Upgraded",
-        "inputs": [{ "name": "implementation", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    { "type": "error", "name": "ECDSAInvalidSignature", "inputs": [] },
-    {
-        "type": "error",
-        "name": "ECDSAInvalidSignatureLength",
-        "inputs": [{ "name": "length", "type": "uint256", "internalType": "uint256" }]
-    },
-    {
-        "type": "error",
-        "name": "ECDSAInvalidSignatureS",
-        "inputs": [{ "name": "s", "type": "bytes32", "internalType": "bytes32" }]
-    },
-    {
-        "type": "error",
-        "name": "ERC20InsufficientAllowance",
-        "inputs": [
-            { "name": "spender", "type": "address", "internalType": "address" },
-            { "name": "allowance", "type": "uint256", "internalType": "uint256" },
-            { "name": "needed", "type": "uint256", "internalType": "uint256" }
-        ]
-    },
-    {
-        "type": "error",
-        "name": "ERC20InsufficientBalance",
-        "inputs": [
-            { "name": "sender", "type": "address", "internalType": "address" },
-            { "name": "balance", "type": "uint256", "internalType": "uint256" },
-            { "name": "needed", "type": "uint256", "internalType": "uint256" }
-        ]
-    },
-    {
-        "type": "error",
-        "name": "ERC20InvalidApprover",
-        "inputs": [{ "name": "approver", "type": "address", "internalType": "address" }]
-    },
-    {
-        "type": "error",
-        "name": "ERC20InvalidReceiver",
-        "inputs": [{ "name": "receiver", "type": "address", "internalType": "address" }]
-    },
-    {
-        "type": "error",
-        "name": "ERC20InvalidSender",
-        "inputs": [{ "name": "sender", "type": "address", "internalType": "address" }]
-    },
-    {
-        "type": "error",
-        "name": "ERC20InvalidSpender",
-        "inputs": [{ "name": "spender", "type": "address", "internalType": "address" }]
-    },
-    {
-        "type": "error",
-        "name": "ERC2612ExpiredSignature",
-        "inputs": [{ "name": "deadline", "type": "uint256", "internalType": "uint256" }]
-    },
-    {
-        "type": "error",
-        "name": "ERC2612InvalidSigner",
-        "inputs": [
-            { "name": "signer", "type": "address", "internalType": "address" },
-            { "name": "owner", "type": "address", "internalType": "address" }
-        ]
-    },
-    {
-        "type": "error",
-        "name": "EmptyCode",
-        "inputs": [{ "name": "migrator_", "type": "address", "internalType": "address" }]
-    },
-    {
-        "type": "error",
-        "name": "InvalidAccountNonce",
-        "inputs": [
-            { "name": "account", "type": "address", "internalType": "address" },
-            { "name": "currentNonce", "type": "uint256", "internalType": "uint256" }
-        ]
-    },
-    { "type": "error", "name": "InvalidInitialization", "inputs": [] },
-    {
-        "type": "error",
-        "name": "MigrationFailed",
-        "inputs": [
-            { "name": "migrator_", "type": "address", "internalType": "address" },
-            { "name": "revertData_", "type": "bytes", "internalType": "bytes" }
-        ]
-    },
-    { "type": "error", "name": "NotInitializing", "inputs": [] },
-    { "type": "error", "name": "ParameterOutOfTypeBounds", "inputs": [] },
-    { "type": "error", "name": "TransferFailed", "inputs": [] },
-    { "type": "error", "name": "TransferFromFailed", "inputs": [] },
-    { "type": "error", "name": "ZeroAmount", "inputs": [] },
-    { "type": "error", "name": "ZeroMigrator", "inputs": [] },
-    { "type": "error", "name": "ZeroParameterRegistry", "inputs": [] },
-    { "type": "error", "name": "ZeroRecipient", "inputs": [] },
-    { "type": "error", "name": "ZeroUnderlying", "inputs": [] }
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "version",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "chainId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "verifyingContract",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "salt",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "extensions",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getPermitDigest",
+    "inputs": [
+      {
+        "name": "owner_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "spender_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "value_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "nonce_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "deadline_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "digest_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "implementation",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "implementation_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "migrate",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "migratorParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "name",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "nonces",
+    "inputs": [
+      {
+        "name": "owner_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "nonce_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "parameterRegistry",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "permit",
+    "inputs": [
+      {
+        "name": "owner_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "spender_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "value_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "deadline_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "v_",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "r_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "s_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "symbol",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "totalSupply",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "transfer",
+    "inputs": [
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "transferFrom",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "underlying",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "withdraw",
+    "inputs": [
+      {
+        "name": "amount_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "withdrawTo",
+    "inputs": [
+      {
+        "name": "recipient_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "success_",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "Approval",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "spender",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "EIP712DomainChanged",
+    "inputs": [],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Migrated",
+    "inputs": [
+      {
+        "name": "migrator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Transfer",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "ECDSAInvalidSignature",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ECDSAInvalidSignatureLength",
+    "inputs": [
+      {
+        "name": "length",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ECDSAInvalidSignatureS",
+    "inputs": [
+      {
+        "name": "s",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC20InsufficientAllowance",
+    "inputs": [
+      {
+        "name": "spender",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "allowance",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "needed",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC20InsufficientBalance",
+    "inputs": [
+      {
+        "name": "sender",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "balance",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "needed",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC20InvalidApprover",
+    "inputs": [
+      {
+        "name": "approver",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC20InvalidReceiver",
+    "inputs": [
+      {
+        "name": "receiver",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC20InvalidSender",
+    "inputs": [
+      {
+        "name": "sender",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC20InvalidSpender",
+    "inputs": [
+      {
+        "name": "spender",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC2612ExpiredSignature",
+    "inputs": [
+      {
+        "name": "deadline",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC2612InvalidSigner",
+    "inputs": [
+      {
+        "name": "signer",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "EmptyCode",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InvalidAccountNonce",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "currentNonce",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InvalidInitialization",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MigrationFailed",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "revertData_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ParameterOutOfTypeBounds",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "TransferFailed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "TransferFromFailed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroAmount",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroMigrator",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroParameterRegistry",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroRecipient",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroUnderlying",
+    "inputs": []
+  }
 ]

--- a/settlement-chain/abis/NodeRegistry.abi.json
+++ b/settlement-chain/abis/NodeRegistry.abi.json
@@ -1,481 +1,1093 @@
 [
-    {
-        "type": "constructor",
-        "inputs": [{ "name": "parameterRegistry_", "type": "address", "internalType": "address" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "NODE_INCREMENT",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "uint32", "internalType": "uint32" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "addNode",
-        "inputs": [
-            { "name": "owner_", "type": "address", "internalType": "address" },
-            { "name": "signingPublicKey_", "type": "bytes", "internalType": "bytes" },
-            { "name": "httpAddress_", "type": "string", "internalType": "string" }
-        ],
-        "outputs": [
-            { "name": "nodeId_", "type": "uint32", "internalType": "uint32" },
-            { "name": "signer_", "type": "address", "internalType": "address" }
-        ],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "addToNetwork",
-        "inputs": [{ "name": "nodeId_", "type": "uint32", "internalType": "uint32" }],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "parameterRegistry_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "NODE_INCREMENT",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "addNode",
+    "inputs": [
+      {
+        "name": "owner_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "signingPublicKey_",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "httpAddress_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "nodeId_",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "signer_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "addToNetwork",
+    "inputs": [
+      {
+        "name": "nodeId_",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "admin",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "admin_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "adminParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "approve",
+    "inputs": [
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "balanceOf",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "canonicalNodesCount",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "canonicalNodesCount_",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getAllNodes",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "allNodes_",
+        "type": "tuple[]",
+        "internalType": "struct INodeRegistry.NodeWithId[]",
+        "components": [
+          {
+            "name": "nodeId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "node",
+            "type": "tuple",
+            "internalType": "struct INodeRegistry.Node",
+            "components": [
+              {
+                "name": "signer",
+                "type": "address",
+                "internalType": "address"
+              },
+              {
+                "name": "isCanonical",
+                "type": "bool",
+                "internalType": "bool"
+              },
+              {
+                "name": "signingPublicKey",
+                "type": "bytes",
+                "internalType": "bytes"
+              },
+              {
+                "name": "httpAddress",
+                "type": "string",
+                "internalType": "string"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getAllNodesCount",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "nodeCount_",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getApproved",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getIsCanonicalNode",
+    "inputs": [
+      {
+        "name": "nodeId_",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "isCanonicalNode_",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getNode",
+    "inputs": [
+      {
+        "name": "nodeId_",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "node_",
+        "type": "tuple",
+        "internalType": "struct INodeRegistry.Node",
+        "components": [
+          {
+            "name": "signer",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "isCanonical",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "signingPublicKey",
+            "type": "bytes",
+            "internalType": "bytes"
+          },
+          {
+            "name": "httpAddress",
+            "type": "string",
+            "internalType": "string"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getSigner",
+    "inputs": [
+      {
+        "name": "nodeId_",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "signer_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "implementation",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "implementation_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "isApprovedForAll",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "maxCanonicalNodes",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "maxCanonicalNodes_",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "maxCanonicalNodesParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "migrate",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "migratorParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "name",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "ownerOf",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "parameterRegistry",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "removeFromNetwork",
+    "inputs": [
+      {
+        "name": "nodeId_",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "safeTransferFrom",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "safeTransferFrom",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "data",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setApprovalForAll",
+    "inputs": [
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "approved",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setBaseURI",
+    "inputs": [
+      {
+        "name": "baseURI_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setHttpAddress",
+    "inputs": [
+      {
+        "name": "nodeId_",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "httpAddress_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "supportsInterface",
+    "inputs": [
+      {
+        "name": "interfaceId",
+        "type": "bytes4",
+        "internalType": "bytes4"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "symbol",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "tokenURI",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "transferFrom",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateAdmin",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateMaxCanonicalNodes",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "AdminUpdated",
+    "inputs": [
+      {
         "name": "admin",
-        "inputs": [],
-        "outputs": [{ "name": "admin_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "adminParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "approve",
-        "inputs": [
-            { "name": "to", "type": "address", "internalType": "address" },
-            { "name": "tokenId", "type": "uint256", "internalType": "uint256" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "balanceOf",
-        "inputs": [{ "name": "owner", "type": "address", "internalType": "address" }],
-        "outputs": [{ "name": "", "type": "uint256", "internalType": "uint256" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "canonicalNodesCount",
-        "inputs": [],
-        "outputs": [{ "name": "canonicalNodesCount_", "type": "uint8", "internalType": "uint8" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "getAllNodes",
-        "inputs": [],
-        "outputs": [
-            {
-                "name": "allNodes_",
-                "type": "tuple[]",
-                "internalType": "struct INodeRegistry.NodeWithId[]",
-                "components": [
-                    { "name": "nodeId", "type": "uint32", "internalType": "uint32" },
-                    {
-                        "name": "node",
-                        "type": "tuple",
-                        "internalType": "struct INodeRegistry.Node",
-                        "components": [
-                            { "name": "signer", "type": "address", "internalType": "address" },
-                            { "name": "isCanonical", "type": "bool", "internalType": "bool" },
-                            { "name": "signingPublicKey", "type": "bytes", "internalType": "bytes" },
-                            { "name": "httpAddress", "type": "string", "internalType": "string" }
-                        ]
-                    }
-                ]
-            }
-        ],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "getAllNodesCount",
-        "inputs": [],
-        "outputs": [{ "name": "nodeCount_", "type": "uint32", "internalType": "uint32" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "getApproved",
-        "inputs": [{ "name": "tokenId", "type": "uint256", "internalType": "uint256" }],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "getIsCanonicalNode",
-        "inputs": [{ "name": "nodeId_", "type": "uint32", "internalType": "uint32" }],
-        "outputs": [{ "name": "isCanonicalNode_", "type": "bool", "internalType": "bool" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "getNode",
-        "inputs": [{ "name": "nodeId_", "type": "uint32", "internalType": "uint32" }],
-        "outputs": [
-            {
-                "name": "node_",
-                "type": "tuple",
-                "internalType": "struct INodeRegistry.Node",
-                "components": [
-                    { "name": "signer", "type": "address", "internalType": "address" },
-                    { "name": "isCanonical", "type": "bool", "internalType": "bool" },
-                    { "name": "signingPublicKey", "type": "bytes", "internalType": "bytes" },
-                    { "name": "httpAddress", "type": "string", "internalType": "string" }
-                ]
-            }
-        ],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "getSigner",
-        "inputs": [{ "name": "nodeId_", "type": "uint32", "internalType": "uint32" }],
-        "outputs": [{ "name": "signer_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "implementation",
-        "inputs": [],
-        "outputs": [{ "name": "implementation_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    { "type": "function", "name": "initialize", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "isApprovedForAll",
-        "inputs": [
-            { "name": "owner", "type": "address", "internalType": "address" },
-            { "name": "operator", "type": "address", "internalType": "address" }
-        ],
-        "outputs": [{ "name": "", "type": "bool", "internalType": "bool" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Approval",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "approved",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ApprovalForAll",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "operator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "approved",
+        "type": "bool",
+        "indexed": false,
+        "internalType": "bool"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "BaseURIUpdated",
+    "inputs": [
+      {
+        "name": "baseURI",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "HttpAddressUpdated",
+    "inputs": [
+      {
+        "name": "nodeId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "httpAddress",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "MaxCanonicalNodesUpdated",
+    "inputs": [
+      {
         "name": "maxCanonicalNodes",
-        "inputs": [],
-        "outputs": [{ "name": "maxCanonicalNodes_", "type": "uint8", "internalType": "uint8" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "maxCanonicalNodesParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    { "type": "function", "name": "migrate", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "migratorParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "name",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "string", "internalType": "string" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "ownerOf",
-        "inputs": [{ "name": "tokenId", "type": "uint256", "internalType": "uint256" }],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "parameterRegistry",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "removeFromNetwork",
-        "inputs": [{ "name": "nodeId_", "type": "uint32", "internalType": "uint32" }],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "safeTransferFrom",
-        "inputs": [
-            { "name": "from", "type": "address", "internalType": "address" },
-            { "name": "to", "type": "address", "internalType": "address" },
-            { "name": "tokenId", "type": "uint256", "internalType": "uint256" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "safeTransferFrom",
-        "inputs": [
-            { "name": "from", "type": "address", "internalType": "address" },
-            { "name": "to", "type": "address", "internalType": "address" },
-            { "name": "tokenId", "type": "uint256", "internalType": "uint256" },
-            { "name": "data", "type": "bytes", "internalType": "bytes" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "setApprovalForAll",
-        "inputs": [
-            { "name": "operator", "type": "address", "internalType": "address" },
-            { "name": "approved", "type": "bool", "internalType": "bool" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "setBaseURI",
-        "inputs": [{ "name": "baseURI_", "type": "string", "internalType": "string" }],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "setHttpAddress",
-        "inputs": [
-            { "name": "nodeId_", "type": "uint32", "internalType": "uint32" },
-            { "name": "httpAddress_", "type": "string", "internalType": "string" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "supportsInterface",
-        "inputs": [{ "name": "interfaceId", "type": "bytes4", "internalType": "bytes4" }],
-        "outputs": [{ "name": "", "type": "bool", "internalType": "bool" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "symbol",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "string", "internalType": "string" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "tokenURI",
-        "inputs": [{ "name": "tokenId", "type": "uint256", "internalType": "uint256" }],
-        "outputs": [{ "name": "", "type": "string", "internalType": "string" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "transferFrom",
-        "inputs": [
-            { "name": "from", "type": "address", "internalType": "address" },
-            { "name": "to", "type": "address", "internalType": "address" },
-            { "name": "tokenId", "type": "uint256", "internalType": "uint256" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    { "type": "function", "name": "updateAdmin", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "updateMaxCanonicalNodes",
-        "inputs": [],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "event",
-        "name": "AdminUpdated",
-        "inputs": [{ "name": "admin", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Approval",
-        "inputs": [
-            { "name": "owner", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "approved", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "tokenId", "type": "uint256", "indexed": true, "internalType": "uint256" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "ApprovalForAll",
-        "inputs": [
-            { "name": "owner", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "operator", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "approved", "type": "bool", "indexed": false, "internalType": "bool" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "BaseURIUpdated",
-        "inputs": [{ "name": "baseURI", "type": "string", "indexed": false, "internalType": "string" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "HttpAddressUpdated",
-        "inputs": [
-            { "name": "nodeId", "type": "uint32", "indexed": true, "internalType": "uint32" },
-            { "name": "httpAddress", "type": "string", "indexed": false, "internalType": "string" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Initialized",
-        "inputs": [{ "name": "version", "type": "uint64", "indexed": false, "internalType": "uint64" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "MaxCanonicalNodesUpdated",
-        "inputs": [{ "name": "maxCanonicalNodes", "type": "uint8", "indexed": false, "internalType": "uint8" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Migrated",
-        "inputs": [{ "name": "migrator", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "NodeAdded",
-        "inputs": [
-            { "name": "nodeId", "type": "uint32", "indexed": true, "internalType": "uint32" },
-            { "name": "owner", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "signer", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "signingPublicKey", "type": "bytes", "indexed": false, "internalType": "bytes" },
-            { "name": "httpAddress", "type": "string", "indexed": false, "internalType": "string" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "NodeAddedToCanonicalNetwork",
-        "inputs": [{ "name": "nodeId", "type": "uint32", "indexed": true, "internalType": "uint32" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "NodeRemovedFromCanonicalNetwork",
-        "inputs": [{ "name": "nodeId", "type": "uint32", "indexed": true, "internalType": "uint32" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Transfer",
-        "inputs": [
-            { "name": "from", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "to", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "tokenId", "type": "uint256", "indexed": true, "internalType": "uint256" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Upgraded",
-        "inputs": [{ "name": "implementation", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "error",
-        "name": "ERC721IncorrectOwner",
-        "inputs": [
-            { "name": "sender", "type": "address", "internalType": "address" },
-            { "name": "tokenId", "type": "uint256", "internalType": "uint256" },
-            { "name": "owner", "type": "address", "internalType": "address" }
-        ]
-    },
-    {
-        "type": "error",
-        "name": "ERC721InsufficientApproval",
-        "inputs": [
-            { "name": "operator", "type": "address", "internalType": "address" },
-            { "name": "tokenId", "type": "uint256", "internalType": "uint256" }
-        ]
-    },
-    {
-        "type": "error",
-        "name": "ERC721InvalidApprover",
-        "inputs": [{ "name": "approver", "type": "address", "internalType": "address" }]
-    },
-    {
-        "type": "error",
-        "name": "ERC721InvalidOperator",
-        "inputs": [{ "name": "operator", "type": "address", "internalType": "address" }]
-    },
-    {
-        "type": "error",
-        "name": "ERC721InvalidOwner",
-        "inputs": [{ "name": "owner", "type": "address", "internalType": "address" }]
-    },
-    {
-        "type": "error",
-        "name": "ERC721InvalidReceiver",
-        "inputs": [{ "name": "receiver", "type": "address", "internalType": "address" }]
-    },
-    {
-        "type": "error",
-        "name": "ERC721InvalidSender",
-        "inputs": [{ "name": "sender", "type": "address", "internalType": "address" }]
-    },
-    {
-        "type": "error",
-        "name": "ERC721NonexistentToken",
-        "inputs": [{ "name": "tokenId", "type": "uint256", "internalType": "uint256" }]
-    },
-    {
-        "type": "error",
-        "name": "EmptyCode",
-        "inputs": [{ "name": "migrator_", "type": "address", "internalType": "address" }]
-    },
-    { "type": "error", "name": "FailedToAddNodeToCanonicalNetwork", "inputs": [] },
-    { "type": "error", "name": "FailedToRemoveNodeFromCanonicalNetwork", "inputs": [] },
-    { "type": "error", "name": "InvalidHttpAddress", "inputs": [] },
-    { "type": "error", "name": "InvalidInitialization", "inputs": [] },
-    { "type": "error", "name": "InvalidOwner", "inputs": [] },
-    { "type": "error", "name": "InvalidSigningPublicKey", "inputs": [] },
-    { "type": "error", "name": "InvalidURI", "inputs": [] },
-    { "type": "error", "name": "MaxCanonicalNodesBelowCurrentCount", "inputs": [] },
-    { "type": "error", "name": "MaxCanonicalNodesReached", "inputs": [] },
-    { "type": "error", "name": "MaxNodesReached", "inputs": [] },
-    {
-        "type": "error",
-        "name": "MigrationFailed",
-        "inputs": [
-            { "name": "migrator_", "type": "address", "internalType": "address" },
-            { "name": "revertData_", "type": "bytes", "internalType": "bytes" }
-        ]
-    },
-    { "type": "error", "name": "NoChange", "inputs": [] },
-    { "type": "error", "name": "NotAdmin", "inputs": [] },
-    { "type": "error", "name": "NotInitializing", "inputs": [] },
-    { "type": "error", "name": "NotNodeOwner", "inputs": [] },
-    { "type": "error", "name": "ParameterOutOfTypeBounds", "inputs": [] },
-    { "type": "error", "name": "ZeroMigrator", "inputs": [] },
-    { "type": "error", "name": "ZeroParameterRegistry", "inputs": [] }
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Migrated",
+    "inputs": [
+      {
+        "name": "migrator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "NodeAdded",
+    "inputs": [
+      {
+        "name": "nodeId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "owner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "signer",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "signingPublicKey",
+        "type": "bytes",
+        "indexed": false,
+        "internalType": "bytes"
+      },
+      {
+        "name": "httpAddress",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "NodeAddedToCanonicalNetwork",
+    "inputs": [
+      {
+        "name": "nodeId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "NodeRemovedFromCanonicalNetwork",
+    "inputs": [
+      {
+        "name": "nodeId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Transfer",
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "to",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "ERC721IncorrectOwner",
+    "inputs": [
+      {
+        "name": "sender",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC721InsufficientApproval",
+    "inputs": [
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC721InvalidApprover",
+    "inputs": [
+      {
+        "name": "approver",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC721InvalidOperator",
+    "inputs": [
+      {
+        "name": "operator",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC721InvalidOwner",
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC721InvalidReceiver",
+    "inputs": [
+      {
+        "name": "receiver",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC721InvalidSender",
+    "inputs": [
+      {
+        "name": "sender",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ERC721NonexistentToken",
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "EmptyCode",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "FailedToAddNodeToCanonicalNetwork",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "FailedToRemoveNodeFromCanonicalNetwork",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidHttpAddress",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidInitialization",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidOwner",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidSigningPublicKey",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidURI",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MaxCanonicalNodesBelowCurrentCount",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MaxCanonicalNodesReached",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MaxNodesReached",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MigrationFailed",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "revertData_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "NoChange",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotAdmin",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotNodeOwner",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ParameterOutOfTypeBounds",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroMigrator",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroParameterRegistry",
+    "inputs": []
+  }
 ]

--- a/settlement-chain/abis/PayerRegistry.abi.json
+++ b/settlement-chain/abis/PayerRegistry.abi.json
@@ -690,6 +690,12 @@
     "name": "UsageSettled",
     "inputs": [
       {
+        "name": "payerReportId",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
         "name": "payer",
         "type": "address",
         "indexed": true,

--- a/settlement-chain/abis/PayerRegistry.abi.json
+++ b/settlement-chain/abis/PayerRegistry.abi.json
@@ -1,423 +1,935 @@
 [
-    {
-        "type": "constructor",
-        "inputs": [
-            { "name": "parameterRegistry_", "type": "address", "internalType": "address" },
-            { "name": "feeToken_", "type": "address", "internalType": "address" }
-        ],
-        "stateMutability": "nonpayable"
-    },
-    { "type": "function", "name": "cancelWithdrawal", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "deposit",
-        "inputs": [
-            { "name": "payer_", "type": "address", "internalType": "address" },
-            { "name": "amount_", "type": "uint96", "internalType": "uint96" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "depositFromUnderlying",
-        "inputs": [
-            { "name": "payer_", "type": "address", "internalType": "address" },
-            { "name": "amount_", "type": "uint96", "internalType": "uint96" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "depositFromUnderlyingWithPermit",
-        "inputs": [
-            { "name": "payer_", "type": "address", "internalType": "address" },
-            { "name": "amount_", "type": "uint96", "internalType": "uint96" },
-            { "name": "deadline_", "type": "uint256", "internalType": "uint256" },
-            { "name": "v_", "type": "uint8", "internalType": "uint8" },
-            { "name": "r_", "type": "bytes32", "internalType": "bytes32" },
-            { "name": "s_", "type": "bytes32", "internalType": "bytes32" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "depositWithPermit",
-        "inputs": [
-            { "name": "payer_", "type": "address", "internalType": "address" },
-            { "name": "amount_", "type": "uint96", "internalType": "uint96" },
-            { "name": "deadline_", "type": "uint256", "internalType": "uint256" },
-            { "name": "v_", "type": "uint8", "internalType": "uint8" },
-            { "name": "r_", "type": "bytes32", "internalType": "bytes32" },
-            { "name": "s_", "type": "bytes32", "internalType": "bytes32" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "excess",
-        "inputs": [],
-        "outputs": [{ "name": "excess_", "type": "uint96", "internalType": "uint96" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "parameterRegistry_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "feeToken_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "cancelWithdrawal",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "deposit",
+    "inputs": [
+      {
+        "name": "payer_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount_",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "depositFromUnderlying",
+    "inputs": [
+      {
+        "name": "payer_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount_",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "depositFromUnderlyingWithPermit",
+    "inputs": [
+      {
+        "name": "payer_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount_",
+        "type": "uint96",
+        "internalType": "uint96"
+      },
+      {
+        "name": "deadline_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "v_",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "r_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "s_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "depositWithPermit",
+    "inputs": [
+      {
+        "name": "payer_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount_",
+        "type": "uint96",
+        "internalType": "uint96"
+      },
+      {
+        "name": "deadline_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "v_",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "r_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "s_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "excess",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "excess_",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "feeDistributor",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "feeDistributor_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "feeDistributorParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "feeToken",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "finalizeWithdrawal",
+    "inputs": [
+      {
+        "name": "recipient_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "finalizeWithdrawalIntoUnderlying",
+    "inputs": [
+      {
+        "name": "recipient_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "getBalance",
+    "inputs": [
+      {
+        "name": "payer_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "balance_",
+        "type": "int104",
+        "internalType": "int104"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getBalances",
+    "inputs": [
+      {
+        "name": "payers_",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "balances_",
+        "type": "int104[]",
+        "internalType": "int104[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getPendingWithdrawal",
+    "inputs": [
+      {
+        "name": "payer_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "pendingWithdrawal_",
+        "type": "uint96",
+        "internalType": "uint96"
+      },
+      {
+        "name": "withdrawableTimestamp_",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "implementation",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "implementation_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "migrate",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "migratorParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "minimumDeposit",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "minimumDeposit_",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "minimumDepositParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "parameterRegistry",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "paused",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "paused_",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "pausedParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "requestWithdrawal",
+    "inputs": [
+      {
+        "name": "amount_",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "sendExcessToFeeDistributor",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "excess_",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "settleUsage",
+    "inputs": [
+      {
+        "name": "payerFees_",
+        "type": "tuple[]",
+        "internalType": "struct IPayerRegistry.PayerFee[]",
+        "components": [
+          {
+            "name": "payer",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "fee",
+            "type": "uint96",
+            "internalType": "uint96"
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "feesSettled_",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "settler",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "settler_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "settlerParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "totalDebt",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "totalDebt_",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "totalDeposits",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "totalDeposits_",
+        "type": "int104",
+        "internalType": "int104"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "totalWithdrawable",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "totalWithdrawable_",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "updateFeeDistributor",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateMinimumDeposit",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updatePauseStatus",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateSettler",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateWithdrawLockPeriod",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "withdrawLockPeriod",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "withdrawLockPeriod_",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "withdrawLockPeriodParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "event",
+    "name": "Deposit",
+    "inputs": [
+      {
+        "name": "payer",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint96",
+        "indexed": false,
+        "internalType": "uint96"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ExcessTransferred",
+    "inputs": [
+      {
+        "name": "amount",
+        "type": "uint96",
+        "indexed": false,
+        "internalType": "uint96"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "FeeDistributorUpdated",
+    "inputs": [
+      {
         "name": "feeDistributor",
-        "inputs": [],
-        "outputs": [{ "name": "feeDistributor_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "feeDistributorParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "feeToken",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "finalizeWithdrawal",
-        "inputs": [{ "name": "recipient_", "type": "address", "internalType": "address" }],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "finalizeWithdrawalIntoUnderlying",
-        "inputs": [{ "name": "recipient_", "type": "address", "internalType": "address" }],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "getBalance",
-        "inputs": [{ "name": "payer_", "type": "address", "internalType": "address" }],
-        "outputs": [{ "name": "balance_", "type": "int104", "internalType": "int104" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "getBalances",
-        "inputs": [{ "name": "payers_", "type": "address[]", "internalType": "address[]" }],
-        "outputs": [{ "name": "balances_", "type": "int104[]", "internalType": "int104[]" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "getPendingWithdrawal",
-        "inputs": [{ "name": "payer_", "type": "address", "internalType": "address" }],
-        "outputs": [
-            { "name": "pendingWithdrawal_", "type": "uint96", "internalType": "uint96" },
-            { "name": "withdrawableTimestamp_", "type": "uint32", "internalType": "uint32" }
-        ],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "implementation",
-        "inputs": [],
-        "outputs": [{ "name": "implementation_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    { "type": "function", "name": "initialize", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    { "type": "function", "name": "migrate", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "migratorParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Migrated",
+    "inputs": [
+      {
+        "name": "migrator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "MinimumDepositUpdated",
+    "inputs": [
+      {
         "name": "minimumDeposit",
-        "inputs": [],
-        "outputs": [{ "name": "minimumDeposit_", "type": "uint96", "internalType": "uint96" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "minimumDepositParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "parameterRegistry",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
+        "type": "uint96",
+        "indexed": false,
+        "internalType": "uint96"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PauseStatusUpdated",
+    "inputs": [
+      {
         "name": "paused",
-        "inputs": [],
-        "outputs": [{ "name": "paused_", "type": "bool", "internalType": "bool" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "pausedParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "requestWithdrawal",
-        "inputs": [{ "name": "amount_", "type": "uint96", "internalType": "uint96" }],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "sendExcessToFeeDistributor",
-        "inputs": [],
-        "outputs": [{ "name": "excess_", "type": "uint96", "internalType": "uint96" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "settleUsage",
-        "inputs": [
-            {
-                "name": "payerFees_",
-                "type": "tuple[]",
-                "internalType": "struct IPayerRegistry.PayerFee[]",
-                "components": [
-                    { "name": "payer", "type": "address", "internalType": "address" },
-                    { "name": "fee", "type": "uint96", "internalType": "uint96" }
-                ]
-            }
-        ],
-        "outputs": [{ "name": "feesSettled_", "type": "uint96", "internalType": "uint96" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
+        "type": "bool",
+        "indexed": true,
+        "internalType": "bool"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "SettlerUpdated",
+    "inputs": [
+      {
         "name": "settler",
-        "inputs": [],
-        "outputs": [{ "name": "settler_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "settlerParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "totalDebt",
-        "inputs": [],
-        "outputs": [{ "name": "totalDebt_", "type": "uint96", "internalType": "uint96" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "totalDeposits",
-        "inputs": [],
-        "outputs": [{ "name": "totalDeposits_", "type": "int104", "internalType": "int104" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "totalWithdrawable",
-        "inputs": [],
-        "outputs": [{ "name": "totalWithdrawable_", "type": "uint96", "internalType": "uint96" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "updateFeeDistributor",
-        "inputs": [],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "updateMinimumDeposit",
-        "inputs": [],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    { "type": "function", "name": "updatePauseStatus", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    { "type": "function", "name": "updateSettler", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "updateWithdrawLockPeriod",
-        "inputs": [],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "UsageSettled",
+    "inputs": [
+      {
+        "name": "payer",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint96",
+        "indexed": false,
+        "internalType": "uint96"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "WithdrawLockPeriodUpdated",
+    "inputs": [
+      {
         "name": "withdrawLockPeriod",
-        "inputs": [],
-        "outputs": [{ "name": "withdrawLockPeriod_", "type": "uint32", "internalType": "uint32" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "withdrawLockPeriodParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "event",
-        "name": "Deposit",
-        "inputs": [
-            { "name": "payer", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "amount", "type": "uint96", "indexed": false, "internalType": "uint96" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "ExcessTransferred",
-        "inputs": [{ "name": "amount", "type": "uint96", "indexed": false, "internalType": "uint96" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "FeeDistributorUpdated",
-        "inputs": [{ "name": "feeDistributor", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Initialized",
-        "inputs": [{ "name": "version", "type": "uint64", "indexed": false, "internalType": "uint64" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Migrated",
-        "inputs": [{ "name": "migrator", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "MinimumDepositUpdated",
-        "inputs": [{ "name": "minimumDeposit", "type": "uint96", "indexed": false, "internalType": "uint96" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "PauseStatusUpdated",
-        "inputs": [{ "name": "paused", "type": "bool", "indexed": true, "internalType": "bool" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "SettlerUpdated",
-        "inputs": [{ "name": "settler", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Upgraded",
-        "inputs": [{ "name": "implementation", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "UsageSettled",
-        "inputs": [
-            { "name": "payer", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "amount", "type": "uint96", "indexed": false, "internalType": "uint96" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "WithdrawLockPeriodUpdated",
-        "inputs": [{ "name": "withdrawLockPeriod", "type": "uint32", "indexed": false, "internalType": "uint32" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "WithdrawalCancelled",
-        "inputs": [{ "name": "payer", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "WithdrawalFinalized",
-        "inputs": [{ "name": "payer", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "WithdrawalRequested",
-        "inputs": [
-            { "name": "payer", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "amount", "type": "uint96", "indexed": false, "internalType": "uint96" },
-            { "name": "withdrawableTimestamp", "type": "uint32", "indexed": false, "internalType": "uint32" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "error",
-        "name": "EmptyCode",
-        "inputs": [{ "name": "migrator_", "type": "address", "internalType": "address" }]
-    },
-    { "type": "error", "name": "InsufficientBalance", "inputs": [] },
-    {
-        "type": "error",
-        "name": "InsufficientDeposit",
-        "inputs": [
-            { "name": "amount", "type": "uint96", "internalType": "uint96" },
-            { "name": "minimumDeposit", "type": "uint96", "internalType": "uint96" }
-        ]
-    },
-    { "type": "error", "name": "InvalidInitialization", "inputs": [] },
-    {
-        "type": "error",
-        "name": "MigrationFailed",
-        "inputs": [
-            { "name": "migrator_", "type": "address", "internalType": "address" },
-            { "name": "revertData_", "type": "bytes", "internalType": "bytes" }
-        ]
-    },
-    { "type": "error", "name": "NoChange", "inputs": [] },
-    { "type": "error", "name": "NoExcess", "inputs": [] },
-    { "type": "error", "name": "NoPendingWithdrawal", "inputs": [] },
-    { "type": "error", "name": "NotInitializing", "inputs": [] },
-    { "type": "error", "name": "NotSettler", "inputs": [] },
-    { "type": "error", "name": "ParameterOutOfTypeBounds", "inputs": [] },
-    { "type": "error", "name": "Paused", "inputs": [] },
-    { "type": "error", "name": "PayerInDebt", "inputs": [] },
-    { "type": "error", "name": "PendingWithdrawalExists", "inputs": [] },
-    { "type": "error", "name": "TransferFromFailed", "inputs": [] },
-    {
-        "type": "error",
-        "name": "WithdrawalNotReady",
-        "inputs": [
-            { "name": "timestamp", "type": "uint32", "internalType": "uint32" },
-            { "name": "withdrawableTimestamp", "type": "uint32", "internalType": "uint32" }
-        ]
-    },
-    { "type": "error", "name": "ZeroFeeDistributor", "inputs": [] },
-    { "type": "error", "name": "ZeroFeeToken", "inputs": [] },
-    { "type": "error", "name": "ZeroMigrator", "inputs": [] },
-    { "type": "error", "name": "ZeroMinimumDeposit", "inputs": [] },
-    { "type": "error", "name": "ZeroParameterRegistry", "inputs": [] },
-    { "type": "error", "name": "ZeroPayer", "inputs": [] },
-    { "type": "error", "name": "ZeroRecipient", "inputs": [] },
-    { "type": "error", "name": "ZeroSettler", "inputs": [] },
-    { "type": "error", "name": "ZeroWithdrawalAmount", "inputs": [] }
+        "type": "uint32",
+        "indexed": false,
+        "internalType": "uint32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "WithdrawalCancelled",
+    "inputs": [
+      {
+        "name": "payer",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "WithdrawalFinalized",
+    "inputs": [
+      {
+        "name": "payer",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "WithdrawalRequested",
+    "inputs": [
+      {
+        "name": "payer",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint96",
+        "indexed": false,
+        "internalType": "uint96"
+      },
+      {
+        "name": "withdrawableTimestamp",
+        "type": "uint32",
+        "indexed": false,
+        "internalType": "uint32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "EmptyCode",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InsufficientBalance",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InsufficientDeposit",
+    "inputs": [
+      {
+        "name": "amount",
+        "type": "uint96",
+        "internalType": "uint96"
+      },
+      {
+        "name": "minimumDeposit",
+        "type": "uint96",
+        "internalType": "uint96"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InvalidInitialization",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MigrationFailed",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "revertData_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "NoChange",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NoExcess",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NoPendingWithdrawal",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotSettler",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ParameterOutOfTypeBounds",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Paused",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "PayerInDebt",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "PendingWithdrawalExists",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "TransferFromFailed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "WithdrawalNotReady",
+    "inputs": [
+      {
+        "name": "timestamp",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "withdrawableTimestamp",
+        "type": "uint32",
+        "internalType": "uint32"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ZeroFeeDistributor",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroFeeToken",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroMigrator",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroMinimumDeposit",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroParameterRegistry",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroPayer",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroRecipient",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroSettler",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroWithdrawalAmount",
+    "inputs": []
+  }
 ]

--- a/settlement-chain/abis/PayerReportManager.abi.json
+++ b/settlement-chain/abis/PayerReportManager.abi.json
@@ -1,314 +1,812 @@
 [
-    {
-        "type": "constructor",
-        "inputs": [
-            { "name": "parameterRegistry_", "type": "address", "internalType": "address" },
-            { "name": "nodeRegistry_", "type": "address", "internalType": "address" },
-            { "name": "payerRegistry_", "type": "address", "internalType": "address" }
-        ],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "DOMAIN_SEPARATOR",
-        "inputs": [],
-        "outputs": [{ "name": "domainSeparator_", "type": "bytes32", "internalType": "bytes32" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "ONE_HUNDRED_PERCENT",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "uint16", "internalType": "uint16" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "PAYER_REPORT_TYPEHASH",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "bytes32", "internalType": "bytes32" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "eip712Domain",
-        "inputs": [],
-        "outputs": [
-            { "name": "fields_", "type": "bytes1", "internalType": "bytes1" },
-            { "name": "name_", "type": "string", "internalType": "string" },
-            { "name": "version_", "type": "string", "internalType": "string" },
-            { "name": "chainId_", "type": "uint256", "internalType": "uint256" },
-            { "name": "verifyingContract_", "type": "address", "internalType": "address" },
-            { "name": "salt_", "type": "bytes32", "internalType": "bytes32" },
-            { "name": "extensions_", "type": "uint256[]", "internalType": "uint256[]" }
-        ],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "getPayerReport",
-        "inputs": [
-            { "name": "originatorNodeId_", "type": "uint32", "internalType": "uint32" },
-            { "name": "payerReportIndex_", "type": "uint256", "internalType": "uint256" }
-        ],
-        "outputs": [
-            {
-                "name": "payerReport_",
-                "type": "tuple",
-                "internalType": "struct IPayerReportManager.PayerReport",
-                "components": [
-                    { "name": "startSequenceId", "type": "uint64", "internalType": "uint64" },
-                    { "name": "endSequenceId", "type": "uint64", "internalType": "uint64" },
-                    { "name": "endMinuteSinceEpoch", "type": "uint32", "internalType": "uint32" },
-                    { "name": "feesSettled", "type": "uint96", "internalType": "uint96" },
-                    { "name": "offset", "type": "uint32", "internalType": "uint32" },
-                    { "name": "isSettled", "type": "bool", "internalType": "bool" },
-                    { "name": "protocolFeeRate", "type": "uint16", "internalType": "uint16" },
-                    { "name": "payersMerkleRoot", "type": "bytes32", "internalType": "bytes32" },
-                    { "name": "nodeIds", "type": "uint32[]", "internalType": "uint32[]" }
-                ]
-            }
-        ],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "getPayerReportDigest",
-        "inputs": [
-            { "name": "originatorNodeId_", "type": "uint32", "internalType": "uint32" },
-            { "name": "startSequenceId_", "type": "uint64", "internalType": "uint64" },
-            { "name": "endSequenceId_", "type": "uint64", "internalType": "uint64" },
-            { "name": "endMinuteSinceEpoch_", "type": "uint32", "internalType": "uint32" },
-            { "name": "payersMerkleRoot_", "type": "bytes32", "internalType": "bytes32" },
-            { "name": "nodeIds_", "type": "uint32[]", "internalType": "uint32[]" }
-        ],
-        "outputs": [{ "name": "digest_", "type": "bytes32", "internalType": "bytes32" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "getPayerReports",
-        "inputs": [
-            { "name": "originatorNodeIds_", "type": "uint32[]", "internalType": "uint32[]" },
-            { "name": "payerReportIndices_", "type": "uint256[]", "internalType": "uint256[]" }
-        ],
-        "outputs": [
-            {
-                "name": "payerReports_",
-                "type": "tuple[]",
-                "internalType": "struct IPayerReportManager.PayerReport[]",
-                "components": [
-                    { "name": "startSequenceId", "type": "uint64", "internalType": "uint64" },
-                    { "name": "endSequenceId", "type": "uint64", "internalType": "uint64" },
-                    { "name": "endMinuteSinceEpoch", "type": "uint32", "internalType": "uint32" },
-                    { "name": "feesSettled", "type": "uint96", "internalType": "uint96" },
-                    { "name": "offset", "type": "uint32", "internalType": "uint32" },
-                    { "name": "isSettled", "type": "bool", "internalType": "bool" },
-                    { "name": "protocolFeeRate", "type": "uint16", "internalType": "uint16" },
-                    { "name": "payersMerkleRoot", "type": "bytes32", "internalType": "bytes32" },
-                    { "name": "nodeIds", "type": "uint32[]", "internalType": "uint32[]" }
-                ]
-            }
-        ],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "implementation",
-        "inputs": [],
-        "outputs": [{ "name": "implementation_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    { "type": "function", "name": "initialize", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    { "type": "function", "name": "migrate", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "migratorParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "nodeRegistry",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "parameterRegistry",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "payerRegistry",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "parameterRegistry_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "nodeRegistry_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "payerRegistry_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "DOMAIN_SEPARATOR",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "domainSeparator_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "ONE_HUNDRED_PERCENT",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "PAYER_REPORT_TYPEHASH",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "eip712Domain",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "fields_",
+        "type": "bytes1",
+        "internalType": "bytes1"
+      },
+      {
+        "name": "name_",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "version_",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "chainId_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "verifyingContract_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "salt_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "extensions_",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getPayerReport",
+    "inputs": [
+      {
+        "name": "originatorNodeId_",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "payerReportIndex_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "payerReport_",
+        "type": "tuple",
+        "internalType": "struct IPayerReportManager.PayerReport",
+        "components": [
+          {
+            "name": "startSequenceId",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "endSequenceId",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "endMinuteSinceEpoch",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "feesSettled",
+            "type": "uint96",
+            "internalType": "uint96"
+          },
+          {
+            "name": "offset",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "isSettled",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "protocolFeeRate",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "payersMerkleRoot",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "nodeIds",
+            "type": "uint32[]",
+            "internalType": "uint32[]"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getPayerReportDigest",
+    "inputs": [
+      {
+        "name": "originatorNodeId_",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "startSequenceId_",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "endSequenceId_",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "endMinuteSinceEpoch_",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "payersMerkleRoot_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "nodeIds_",
+        "type": "uint32[]",
+        "internalType": "uint32[]"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "digest_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getPayerReports",
+    "inputs": [
+      {
+        "name": "originatorNodeIds_",
+        "type": "uint32[]",
+        "internalType": "uint32[]"
+      },
+      {
+        "name": "payerReportIndices_",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "payerReports_",
+        "type": "tuple[]",
+        "internalType": "struct IPayerReportManager.PayerReport[]",
+        "components": [
+          {
+            "name": "startSequenceId",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "endSequenceId",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "endMinuteSinceEpoch",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "feesSettled",
+            "type": "uint96",
+            "internalType": "uint96"
+          },
+          {
+            "name": "offset",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "isSettled",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "protocolFeeRate",
+            "type": "uint16",
+            "internalType": "uint16"
+          },
+          {
+            "name": "payersMerkleRoot",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "nodeIds",
+            "type": "uint32[]",
+            "internalType": "uint32[]"
+          }
+        ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "implementation",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "implementation_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "migrate",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "migratorParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "nodeRegistry",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "parameterRegistry",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "payerRegistry",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "protocolFeeRate",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "protocolFeeRate_",
+        "type": "uint16",
+        "internalType": "uint16"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "protocolFeeRateParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "settle",
+    "inputs": [
+      {
+        "name": "originatorNodeId_",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "payerReportIndex_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "payerFees_",
+        "type": "bytes[]",
+        "internalType": "bytes[]"
+      },
+      {
+        "name": "proofElements_",
+        "type": "bytes32[]",
+        "internalType": "bytes32[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "submit",
+    "inputs": [
+      {
+        "name": "originatorNodeId_",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "startSequenceId_",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "endSequenceId_",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "endMinuteSinceEpoch_",
+        "type": "uint32",
+        "internalType": "uint32"
+      },
+      {
+        "name": "payersMerkleRoot_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "nodeIds_",
+        "type": "uint32[]",
+        "internalType": "uint32[]"
+      },
+      {
+        "name": "signatures_",
+        "type": "tuple[]",
+        "internalType": "struct IPayerReportManager.PayerReportSignature[]",
+        "components": [
+          {
+            "name": "nodeId",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "signature",
+            "type": "bytes",
+            "internalType": "bytes"
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "payerReportIndex_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateProtocolFeeRate",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "EIP712DomainChanged",
+    "inputs": [],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Migrated",
+    "inputs": [
+      {
+        "name": "migrator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PayerReportSubmitted",
+    "inputs": [
+      {
+        "name": "originatorNodeId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "payerReportIndex",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "startSequenceId",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      },
+      {
+        "name": "endSequenceId",
+        "type": "uint64",
+        "indexed": true,
+        "internalType": "uint64"
+      },
+      {
+        "name": "endMinuteSinceEpoch",
+        "type": "uint32",
+        "indexed": false,
+        "internalType": "uint32"
+      },
+      {
+        "name": "payersMerkleRoot",
+        "type": "bytes32",
+        "indexed": false,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "nodeIds",
+        "type": "uint32[]",
+        "indexed": false,
+        "internalType": "uint32[]"
+      },
+      {
+        "name": "signingNodeIds",
+        "type": "uint32[]",
+        "indexed": false,
+        "internalType": "uint32[]"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PayerReportSubsetSettled",
+    "inputs": [
+      {
+        "name": "originatorNodeId",
+        "type": "uint32",
+        "indexed": true,
+        "internalType": "uint32"
+      },
+      {
+        "name": "payerReportIndex",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "count",
+        "type": "uint32",
+        "indexed": false,
+        "internalType": "uint32"
+      },
+      {
+        "name": "remaining",
+        "type": "uint32",
+        "indexed": false,
+        "internalType": "uint32"
+      },
+      {
+        "name": "feesSettled",
+        "type": "uint96",
+        "indexed": false,
+        "internalType": "uint96"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ProtocolFeeRateUpdated",
+    "inputs": [
+      {
         "name": "protocolFeeRate",
-        "inputs": [],
-        "outputs": [{ "name": "protocolFeeRate_", "type": "uint16", "internalType": "uint16" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "protocolFeeRateParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "settle",
-        "inputs": [
-            { "name": "originatorNodeId_", "type": "uint32", "internalType": "uint32" },
-            { "name": "payerReportIndex_", "type": "uint256", "internalType": "uint256" },
-            { "name": "payerFees_", "type": "bytes[]", "internalType": "bytes[]" },
-            { "name": "proofElements_", "type": "bytes32[]", "internalType": "bytes32[]" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "submit",
-        "inputs": [
-            { "name": "originatorNodeId_", "type": "uint32", "internalType": "uint32" },
-            { "name": "startSequenceId_", "type": "uint64", "internalType": "uint64" },
-            { "name": "endSequenceId_", "type": "uint64", "internalType": "uint64" },
-            { "name": "endMinuteSinceEpoch_", "type": "uint32", "internalType": "uint32" },
-            { "name": "payersMerkleRoot_", "type": "bytes32", "internalType": "bytes32" },
-            { "name": "nodeIds_", "type": "uint32[]", "internalType": "uint32[]" },
-            {
-                "name": "signatures_",
-                "type": "tuple[]",
-                "internalType": "struct IPayerReportManager.PayerReportSignature[]",
-                "components": [
-                    { "name": "nodeId", "type": "uint32", "internalType": "uint32" },
-                    { "name": "signature", "type": "bytes", "internalType": "bytes" }
-                ]
-            }
-        ],
-        "outputs": [{ "name": "payerReportIndex_", "type": "uint256", "internalType": "uint256" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "updateProtocolFeeRate",
-        "inputs": [],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    { "type": "event", "name": "EIP712DomainChanged", "inputs": [], "anonymous": false },
-    {
-        "type": "event",
-        "name": "Initialized",
-        "inputs": [{ "name": "version", "type": "uint64", "indexed": false, "internalType": "uint64" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Migrated",
-        "inputs": [{ "name": "migrator", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "PayerReportSubmitted",
-        "inputs": [
-            { "name": "originatorNodeId", "type": "uint32", "indexed": true, "internalType": "uint32" },
-            { "name": "payerReportIndex", "type": "uint256", "indexed": true, "internalType": "uint256" },
-            { "name": "startSequenceId", "type": "uint64", "indexed": false, "internalType": "uint64" },
-            { "name": "endSequenceId", "type": "uint64", "indexed": true, "internalType": "uint64" },
-            { "name": "endMinuteSinceEpoch", "type": "uint32", "indexed": false, "internalType": "uint32" },
-            { "name": "payersMerkleRoot", "type": "bytes32", "indexed": false, "internalType": "bytes32" },
-            { "name": "nodeIds", "type": "uint32[]", "indexed": false, "internalType": "uint32[]" },
-            { "name": "signingNodeIds", "type": "uint32[]", "indexed": false, "internalType": "uint32[]" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "PayerReportSubsetSettled",
-        "inputs": [
-            { "name": "originatorNodeId", "type": "uint32", "indexed": true, "internalType": "uint32" },
-            { "name": "payerReportIndex", "type": "uint256", "indexed": true, "internalType": "uint256" },
-            { "name": "count", "type": "uint32", "indexed": false, "internalType": "uint32" },
-            { "name": "remaining", "type": "uint32", "indexed": false, "internalType": "uint32" },
-            { "name": "feesSettled", "type": "uint96", "indexed": false, "internalType": "uint96" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "ProtocolFeeRateUpdated",
-        "inputs": [{ "name": "protocolFeeRate", "type": "uint16", "indexed": false, "internalType": "uint16" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Upgraded",
-        "inputs": [{ "name": "implementation", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    { "type": "error", "name": "ArrayLengthMismatch", "inputs": [] },
-    {
-        "type": "error",
-        "name": "EmptyCode",
-        "inputs": [{ "name": "migrator_", "type": "address", "internalType": "address" }]
-    },
-    {
-        "type": "error",
-        "name": "InsufficientSignatures",
-        "inputs": [
-            { "name": "validSignatureCount", "type": "uint8", "internalType": "uint8" },
-            { "name": "requiredSignatureCount", "type": "uint8", "internalType": "uint8" }
-        ]
-    },
-    { "type": "error", "name": "InvalidBitCount32Input", "inputs": [] },
-    { "type": "error", "name": "InvalidInitialization", "inputs": [] },
-    { "type": "error", "name": "InvalidLeafCount", "inputs": [] },
-    { "type": "error", "name": "InvalidProof", "inputs": [] },
-    { "type": "error", "name": "InvalidProtocolFeeRate", "inputs": [] },
-    { "type": "error", "name": "InvalidSequenceIds", "inputs": [] },
-    {
-        "type": "error",
-        "name": "InvalidStartSequenceId",
-        "inputs": [
-            { "name": "startSequenceId", "type": "uint64", "internalType": "uint64" },
-            { "name": "lastSequenceId", "type": "uint64", "internalType": "uint64" }
-        ]
-    },
-    {
-        "type": "error",
-        "name": "MigrationFailed",
-        "inputs": [
-            { "name": "migrator_", "type": "address", "internalType": "address" },
-            { "name": "revertData_", "type": "bytes", "internalType": "bytes" }
-        ]
-    },
-    { "type": "error", "name": "NoChange", "inputs": [] },
-    { "type": "error", "name": "NoLeaves", "inputs": [] },
-    { "type": "error", "name": "NoProofElements", "inputs": [] },
-    { "type": "error", "name": "NotInitializing", "inputs": [] },
-    { "type": "error", "name": "ParameterOutOfTypeBounds", "inputs": [] },
-    { "type": "error", "name": "PayerFeesLengthTooLong", "inputs": [] },
-    { "type": "error", "name": "PayerReportEntirelySettled", "inputs": [] },
-    { "type": "error", "name": "PayerReportIndexOutOfBounds", "inputs": [] },
-    {
-        "type": "error",
-        "name": "SettleUsageFailed",
-        "inputs": [{ "name": "returnData_", "type": "bytes", "internalType": "bytes" }]
-    },
-    { "type": "error", "name": "UnorderedNodeIds", "inputs": [] },
-    { "type": "error", "name": "ZeroMigrator", "inputs": [] },
-    { "type": "error", "name": "ZeroNodeRegistry", "inputs": [] },
-    { "type": "error", "name": "ZeroParameterRegistry", "inputs": [] },
-    { "type": "error", "name": "ZeroPayerRegistry", "inputs": [] }
+        "type": "uint16",
+        "indexed": false,
+        "internalType": "uint16"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "ArrayLengthMismatch",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "EmptyCode",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InsufficientSignatures",
+    "inputs": [
+      {
+        "name": "validSignatureCount",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "requiredSignatureCount",
+        "type": "uint8",
+        "internalType": "uint8"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InvalidBitCount32Input",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidInitialization",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidLeafCount",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidProof",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidProtocolFeeRate",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidSequenceIds",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidStartSequenceId",
+    "inputs": [
+      {
+        "name": "startSequenceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      },
+      {
+        "name": "lastSequenceId",
+        "type": "uint64",
+        "internalType": "uint64"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "MigrationFailed",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "revertData_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "NoChange",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NoLeaves",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NoProofElements",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ParameterOutOfTypeBounds",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "PayerFeesLengthTooLong",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "PayerReportEntirelySettled",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "PayerReportIndexOutOfBounds",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "SettleUsageFailed",
+    "inputs": [
+      {
+        "name": "returnData_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "UnorderedNodeIds",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroMigrator",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroNodeRegistry",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroParameterRegistry",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroPayerRegistry",
+    "inputs": []
+  }
 ]

--- a/settlement-chain/abis/RateRegistry.abi.json
+++ b/settlement-chain/abis/RateRegistry.abi.json
@@ -1,140 +1,331 @@
 [
-    {
-        "type": "constructor",
-        "inputs": [{ "name": "parameterRegistry_", "type": "address", "internalType": "address" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "congestionFeeParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "getRates",
-        "inputs": [
-            { "name": "fromIndex_", "type": "uint256", "internalType": "uint256" },
-            { "name": "count_", "type": "uint256", "internalType": "uint256" }
-        ],
-        "outputs": [
-            {
-                "name": "rates_",
-                "type": "tuple[]",
-                "internalType": "struct IRateRegistry.Rates[]",
-                "components": [
-                    { "name": "messageFee", "type": "uint64", "internalType": "uint64" },
-                    { "name": "storageFee", "type": "uint64", "internalType": "uint64" },
-                    { "name": "congestionFee", "type": "uint64", "internalType": "uint64" },
-                    { "name": "targetRatePerMinute", "type": "uint64", "internalType": "uint64" },
-                    { "name": "startTime", "type": "uint64", "internalType": "uint64" }
-                ]
-            }
-        ],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "getRatesCount",
-        "inputs": [],
-        "outputs": [{ "name": "count_", "type": "uint256", "internalType": "uint256" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "implementation",
-        "inputs": [],
-        "outputs": [{ "name": "implementation_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    { "type": "function", "name": "initialize", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "messageFeeParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    { "type": "function", "name": "migrate", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "migratorParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "parameterRegistry",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "storageFeeParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "targetRatePerMinuteParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    { "type": "function", "name": "updateRates", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "event",
-        "name": "Initialized",
-        "inputs": [{ "name": "version", "type": "uint64", "indexed": false, "internalType": "uint64" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Migrated",
-        "inputs": [{ "name": "migrator", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "RatesUpdated",
-        "inputs": [
-            { "name": "messageFee", "type": "uint64", "indexed": false, "internalType": "uint64" },
-            { "name": "storageFee", "type": "uint64", "indexed": false, "internalType": "uint64" },
-            { "name": "congestionFee", "type": "uint64", "indexed": false, "internalType": "uint64" },
-            { "name": "targetRatePerMinute", "type": "uint64", "indexed": false, "internalType": "uint64" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Upgraded",
-        "inputs": [{ "name": "implementation", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "error",
-        "name": "EmptyCode",
-        "inputs": [{ "name": "migrator_", "type": "address", "internalType": "address" }]
-    },
-    { "type": "error", "name": "EndIndexOutOfRange", "inputs": [] },
-    { "type": "error", "name": "FromIndexOutOfRange", "inputs": [] },
-    { "type": "error", "name": "InvalidInitialization", "inputs": [] },
-    {
-        "type": "error",
-        "name": "MigrationFailed",
-        "inputs": [
-            { "name": "migrator_", "type": "address", "internalType": "address" },
-            { "name": "revertData_", "type": "bytes", "internalType": "bytes" }
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "parameterRegistry_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "congestionFeeParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "getRates",
+    "inputs": [
+      {
+        "name": "fromIndex_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "count_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "rates_",
+        "type": "tuple[]",
+        "internalType": "struct IRateRegistry.Rates[]",
+        "components": [
+          {
+            "name": "messageFee",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "storageFee",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "congestionFee",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "targetRatePerMinute",
+            "type": "uint64",
+            "internalType": "uint64"
+          },
+          {
+            "name": "startTime",
+            "type": "uint64",
+            "internalType": "uint64"
+          }
         ]
-    },
-    { "type": "error", "name": "NoChange", "inputs": [] },
-    { "type": "error", "name": "NotInitializing", "inputs": [] },
-    { "type": "error", "name": "ParameterOutOfTypeBounds", "inputs": [] },
-    { "type": "error", "name": "ZeroCount", "inputs": [] },
-    { "type": "error", "name": "ZeroMigrator", "inputs": [] },
-    { "type": "error", "name": "ZeroParameterRegistry", "inputs": [] }
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getRatesCount",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "count_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "implementation",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "implementation_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "messageFeeParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "migrate",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "migratorParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "parameterRegistry",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "storageFeeParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "targetRatePerMinuteParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "updateRates",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Migrated",
+    "inputs": [
+      {
+        "name": "migrator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RatesUpdated",
+    "inputs": [
+      {
+        "name": "messageFee",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      },
+      {
+        "name": "storageFee",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      },
+      {
+        "name": "congestionFee",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      },
+      {
+        "name": "targetRatePerMinute",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "EmptyCode",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "EndIndexOutOfRange",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "FromIndexOutOfRange",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidInitialization",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MigrationFailed",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "revertData_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "NoChange",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ParameterOutOfTypeBounds",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroCount",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroMigrator",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroParameterRegistry",
+    "inputs": []
+  }
 ]

--- a/settlement-chain/abis/SettlementChainGateway.abi.json
+++ b/settlement-chain/abis/SettlementChainGateway.abi.json
@@ -1,342 +1,913 @@
 [
-    {
-        "type": "constructor",
-        "inputs": [
-            { "name": "parameterRegistry_", "type": "address", "internalType": "address" },
-            { "name": "appChainGateway_", "type": "address", "internalType": "address" },
-            { "name": "feeToken_", "type": "address", "internalType": "address" }
-        ],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "appChainAlias",
-        "inputs": [],
-        "outputs": [{ "name": "alias_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "appChainGateway",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "calculateMaxDepositFee",
-        "inputs": [
-            { "name": "chainId_", "type": "uint256", "internalType": "uint256" },
-            { "name": "gasLimit_", "type": "uint256", "internalType": "uint256" },
-            { "name": "maxFeePerGas_", "type": "uint256", "internalType": "uint256" },
-            { "name": "maxBaseFee_", "type": "uint256", "internalType": "uint256" }
-        ],
-        "outputs": [{ "name": "fees_", "type": "uint256", "internalType": "uint256" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "deposit",
-        "inputs": [
-            { "name": "chainId_", "type": "uint256", "internalType": "uint256" },
-            { "name": "recipient_", "type": "address", "internalType": "address" },
-            { "name": "amount_", "type": "uint256", "internalType": "uint256" },
-            { "name": "gasLimit_", "type": "uint256", "internalType": "uint256" },
-            { "name": "maxFeePerGas_", "type": "uint256", "internalType": "uint256" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "depositFromUnderlying",
-        "inputs": [
-            { "name": "chainId_", "type": "uint256", "internalType": "uint256" },
-            { "name": "recipient_", "type": "address", "internalType": "address" },
-            { "name": "amount_", "type": "uint256", "internalType": "uint256" },
-            { "name": "gasLimit_", "type": "uint256", "internalType": "uint256" },
-            { "name": "maxFeePerGas_", "type": "uint256", "internalType": "uint256" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "depositFromUnderlyingWithPermit",
-        "inputs": [
-            { "name": "chainId_", "type": "uint256", "internalType": "uint256" },
-            { "name": "recipient_", "type": "address", "internalType": "address" },
-            { "name": "amount_", "type": "uint256", "internalType": "uint256" },
-            { "name": "gasLimit_", "type": "uint256", "internalType": "uint256" },
-            { "name": "maxFeePerGas_", "type": "uint256", "internalType": "uint256" },
-            { "name": "deadline_", "type": "uint256", "internalType": "uint256" },
-            { "name": "v_", "type": "uint8", "internalType": "uint8" },
-            { "name": "r_", "type": "bytes32", "internalType": "bytes32" },
-            { "name": "s_", "type": "bytes32", "internalType": "bytes32" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "depositWithPermit",
-        "inputs": [
-            { "name": "chainId_", "type": "uint256", "internalType": "uint256" },
-            { "name": "recipient_", "type": "address", "internalType": "address" },
-            { "name": "amount_", "type": "uint256", "internalType": "uint256" },
-            { "name": "gasLimit_", "type": "uint256", "internalType": "uint256" },
-            { "name": "maxFeePerGas_", "type": "uint256", "internalType": "uint256" },
-            { "name": "deadline_", "type": "uint256", "internalType": "uint256" },
-            { "name": "v_", "type": "uint8", "internalType": "uint8" },
-            { "name": "r_", "type": "bytes32", "internalType": "bytes32" },
-            { "name": "s_", "type": "bytes32", "internalType": "bytes32" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "feeToken",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "getInbox",
-        "inputs": [{ "name": "chainId_", "type": "uint256", "internalType": "uint256" }],
-        "outputs": [{ "name": "inbox_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "implementation",
-        "inputs": [],
-        "outputs": [{ "name": "implementation_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "inboxParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    { "type": "function", "name": "initialize", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    { "type": "function", "name": "migrate", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "migratorParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "parameterRegistry",
-        "inputs": [],
-        "outputs": [{ "name": "", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
+  {
+    "type": "constructor",
+    "inputs": [
+      {
+        "name": "parameterRegistry_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "appChainGateway_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "feeToken_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "appChainAlias",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "alias_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "appChainGateway",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "calculateMaxDepositFee",
+    "inputs": [
+      {
+        "name": "chainId_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "gasLimit_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "maxFeePerGas_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "maxBaseFee_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "fees_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "deposit",
+    "inputs": [
+      {
+        "name": "chainId_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "recipient_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "gasLimit_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "maxFeePerGas_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "depositFromUnderlying",
+    "inputs": [
+      {
+        "name": "chainId_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "recipient_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "gasLimit_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "maxFeePerGas_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "depositFromUnderlyingWithPermit",
+    "inputs": [
+      {
+        "name": "chainId_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "recipient_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "gasLimit_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "maxFeePerGas_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "deadline_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "v_",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "r_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "s_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "depositWithPermit",
+    "inputs": [
+      {
+        "name": "chainId_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "recipient_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "gasLimit_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "maxFeePerGas_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "deadline_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "v_",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "r_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "s_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "feeToken",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getInbox",
+    "inputs": [
+      {
+        "name": "chainId_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "inbox_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "implementation",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "implementation_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "inboxParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "migrate",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "migratorParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "parameterRegistry",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "paused",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "paused_",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "pausedParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "receiveWithdrawal",
+    "inputs": [
+      {
+        "name": "recipient_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "amount_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "receiveWithdrawalIntoUnderlying",
+    "inputs": [
+      {
+        "name": "recipient_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "amount_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "sendParameters",
+    "inputs": [
+      {
+        "name": "chainIds_",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      },
+      {
+        "name": "keys_",
+        "type": "string[]",
+        "internalType": "string[]"
+      },
+      {
+        "name": "gasLimit_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "maxFeePerGas_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "amountToSend_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "totalSent_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "sendParametersFromUnderlying",
+    "inputs": [
+      {
+        "name": "chainIds_",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      },
+      {
+        "name": "keys_",
+        "type": "string[]",
+        "internalType": "string[]"
+      },
+      {
+        "name": "gasLimit_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "maxFeePerGas_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "amountToSend_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "totalSent_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "sendParametersFromUnderlyingWithPermit",
+    "inputs": [
+      {
+        "name": "chainIds_",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      },
+      {
+        "name": "keys_",
+        "type": "string[]",
+        "internalType": "string[]"
+      },
+      {
+        "name": "gasLimit_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "maxFeePerGas_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "amountToSend_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "deadline_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "v_",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "r_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "s_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "totalSent_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "sendParametersWithPermit",
+    "inputs": [
+      {
+        "name": "chainIds_",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      },
+      {
+        "name": "keys_",
+        "type": "string[]",
+        "internalType": "string[]"
+      },
+      {
+        "name": "gasLimit_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "maxFeePerGas_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "amountToSend_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "deadline_",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "v_",
+        "type": "uint8",
+        "internalType": "uint8"
+      },
+      {
+        "name": "r_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "s_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "totalSent_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateInbox",
+    "inputs": [
+      {
+        "name": "chainId_",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updatePauseStatus",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "Deposit",
+    "inputs": [
+      {
+        "name": "chainId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "messageNumber",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "InboxUpdated",
+    "inputs": [
+      {
+        "name": "chainId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "inbox",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Migrated",
+    "inputs": [
+      {
+        "name": "migrator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ParametersSent",
+    "inputs": [
+      {
+        "name": "chainId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "messageNumber",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "nonce",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "keys",
+        "type": "string[]",
+        "indexed": false,
+        "internalType": "string[]"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "PauseStatusUpdated",
+    "inputs": [
+      {
         "name": "paused",
-        "inputs": [],
-        "outputs": [{ "name": "paused_", "type": "bool", "internalType": "bool" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "pausedParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "receiveWithdrawal",
-        "inputs": [{ "name": "recipient_", "type": "address", "internalType": "address" }],
-        "outputs": [{ "name": "amount_", "type": "uint256", "internalType": "uint256" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "receiveWithdrawalIntoUnderlying",
-        "inputs": [{ "name": "recipient_", "type": "address", "internalType": "address" }],
-        "outputs": [{ "name": "amount_", "type": "uint256", "internalType": "uint256" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "sendParameters",
-        "inputs": [
-            { "name": "chainIds_", "type": "uint256[]", "internalType": "uint256[]" },
-            { "name": "keys_", "type": "string[]", "internalType": "string[]" },
-            { "name": "gasLimit_", "type": "uint256", "internalType": "uint256" },
-            { "name": "maxFeePerGas_", "type": "uint256", "internalType": "uint256" },
-            { "name": "amountToSend_", "type": "uint256", "internalType": "uint256" }
-        ],
-        "outputs": [{ "name": "totalSent_", "type": "uint256", "internalType": "uint256" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "sendParametersFromUnderlying",
-        "inputs": [
-            { "name": "chainIds_", "type": "uint256[]", "internalType": "uint256[]" },
-            { "name": "keys_", "type": "string[]", "internalType": "string[]" },
-            { "name": "gasLimit_", "type": "uint256", "internalType": "uint256" },
-            { "name": "maxFeePerGas_", "type": "uint256", "internalType": "uint256" },
-            { "name": "amountToSend_", "type": "uint256", "internalType": "uint256" }
-        ],
-        "outputs": [{ "name": "totalSent_", "type": "uint256", "internalType": "uint256" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "sendParametersFromUnderlyingWithPermit",
-        "inputs": [
-            { "name": "chainIds_", "type": "uint256[]", "internalType": "uint256[]" },
-            { "name": "keys_", "type": "string[]", "internalType": "string[]" },
-            { "name": "gasLimit_", "type": "uint256", "internalType": "uint256" },
-            { "name": "maxFeePerGas_", "type": "uint256", "internalType": "uint256" },
-            { "name": "amountToSend_", "type": "uint256", "internalType": "uint256" },
-            { "name": "deadline_", "type": "uint256", "internalType": "uint256" },
-            { "name": "v_", "type": "uint8", "internalType": "uint8" },
-            { "name": "r_", "type": "bytes32", "internalType": "bytes32" },
-            { "name": "s_", "type": "bytes32", "internalType": "bytes32" }
-        ],
-        "outputs": [{ "name": "totalSent_", "type": "uint256", "internalType": "uint256" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "sendParametersWithPermit",
-        "inputs": [
-            { "name": "chainIds_", "type": "uint256[]", "internalType": "uint256[]" },
-            { "name": "keys_", "type": "string[]", "internalType": "string[]" },
-            { "name": "gasLimit_", "type": "uint256", "internalType": "uint256" },
-            { "name": "maxFeePerGas_", "type": "uint256", "internalType": "uint256" },
-            { "name": "amountToSend_", "type": "uint256", "internalType": "uint256" },
-            { "name": "deadline_", "type": "uint256", "internalType": "uint256" },
-            { "name": "v_", "type": "uint8", "internalType": "uint8" },
-            { "name": "r_", "type": "bytes32", "internalType": "bytes32" },
-            { "name": "s_", "type": "bytes32", "internalType": "bytes32" }
-        ],
-        "outputs": [{ "name": "totalSent_", "type": "uint256", "internalType": "uint256" }],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "updateInbox",
-        "inputs": [{ "name": "chainId_", "type": "uint256", "internalType": "uint256" }],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    { "type": "function", "name": "updatePauseStatus", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "event",
-        "name": "Deposit",
-        "inputs": [
-            { "name": "chainId", "type": "uint256", "indexed": true, "internalType": "uint256" },
-            { "name": "messageNumber", "type": "uint256", "indexed": true, "internalType": "uint256" },
-            { "name": "amount", "type": "uint256", "indexed": false, "internalType": "uint256" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "InboxUpdated",
-        "inputs": [
-            { "name": "chainId", "type": "uint256", "indexed": true, "internalType": "uint256" },
-            { "name": "inbox", "type": "address", "indexed": true, "internalType": "address" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Initialized",
-        "inputs": [{ "name": "version", "type": "uint64", "indexed": false, "internalType": "uint64" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Migrated",
-        "inputs": [{ "name": "migrator", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "ParametersSent",
-        "inputs": [
-            { "name": "chainId", "type": "uint256", "indexed": true, "internalType": "uint256" },
-            { "name": "messageNumber", "type": "uint256", "indexed": true, "internalType": "uint256" },
-            { "name": "nonce", "type": "uint256", "indexed": false, "internalType": "uint256" },
-            { "name": "keys", "type": "string[]", "indexed": false, "internalType": "string[]" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "PauseStatusUpdated",
-        "inputs": [{ "name": "paused", "type": "bool", "indexed": true, "internalType": "bool" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Upgraded",
-        "inputs": [{ "name": "implementation", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "WithdrawalReceived",
-        "inputs": [
-            { "name": "recipient", "type": "address", "indexed": true, "internalType": "address" },
-            { "name": "amount", "type": "uint256", "indexed": false, "internalType": "uint256" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "error",
-        "name": "EmptyCode",
-        "inputs": [{ "name": "migrator_", "type": "address", "internalType": "address" }]
-    },
-    {
-        "type": "error",
-        "name": "InsufficientAmount",
-        "inputs": [
-            { "name": "appChainAmount", "type": "uint256", "internalType": "uint256" },
-            { "name": "maxTotalCosts", "type": "uint256", "internalType": "uint256" }
-        ]
-    },
-    { "type": "error", "name": "InvalidFeeTokenDecimals", "inputs": [] },
-    { "type": "error", "name": "InvalidInitialization", "inputs": [] },
-    {
-        "type": "error",
-        "name": "MigrationFailed",
-        "inputs": [
-            { "name": "migrator_", "type": "address", "internalType": "address" },
-            { "name": "revertData_", "type": "bytes", "internalType": "bytes" }
-        ]
-    },
-    { "type": "error", "name": "NoChainIds", "inputs": [] },
-    { "type": "error", "name": "NoChange", "inputs": [] },
-    { "type": "error", "name": "NoKeys", "inputs": [] },
-    { "type": "error", "name": "NotInitializing", "inputs": [] },
-    { "type": "error", "name": "ParameterOutOfTypeBounds", "inputs": [] },
-    { "type": "error", "name": "Paused", "inputs": [] },
-    { "type": "error", "name": "TransferFromFailed", "inputs": [] },
-    {
-        "type": "error",
-        "name": "UnsupportedChainId",
-        "inputs": [{ "name": "chainId", "type": "uint256", "internalType": "uint256" }]
-    },
-    { "type": "error", "name": "ZeroAmount", "inputs": [] },
-    { "type": "error", "name": "ZeroAppChainGateway", "inputs": [] },
-    { "type": "error", "name": "ZeroBalance", "inputs": [] },
-    { "type": "error", "name": "ZeroFeeToken", "inputs": [] },
-    { "type": "error", "name": "ZeroMigrator", "inputs": [] },
-    { "type": "error", "name": "ZeroParameterRegistry", "inputs": [] },
-    { "type": "error", "name": "ZeroRecipient", "inputs": [] }
+        "type": "bool",
+        "indexed": true,
+        "internalType": "bool"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
+        "name": "implementation",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "WithdrawalReceived",
+    "inputs": [
+      {
+        "name": "recipient",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "EmptyCode",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InsufficientAmount",
+    "inputs": [
+      {
+        "name": "appChainAmount",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "maxTotalCosts",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InvalidFeeTokenDecimals",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidInitialization",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MigrationFailed",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "revertData_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "NoChainIds",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NoChange",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NoKeys",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ParameterOutOfTypeBounds",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Paused",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "TransferFromFailed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "UnsupportedChainId",
+    "inputs": [
+      {
+        "name": "chainId",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ZeroAmount",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroAppChainGateway",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroBalance",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroFeeToken",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroMigrator",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroParameterRegistry",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroRecipient",
+    "inputs": []
+  }
 ]

--- a/settlement-chain/abis/SettlementChainParameterRegistry.abi.json
+++ b/settlement-chain/abis/SettlementChainParameterRegistry.abi.json
@@ -1,130 +1,305 @@
 [
-    {
-        "type": "function",
-        "name": "adminParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "get",
-        "inputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "outputs": [{ "name": "value_", "type": "bytes32", "internalType": "bytes32" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "get",
-        "inputs": [{ "name": "keys_", "type": "string[]", "internalType": "string[]" }],
-        "outputs": [{ "name": "values_", "type": "bytes32[]", "internalType": "bytes32[]" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
+  {
+    "type": "function",
+    "name": "adminParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "get",
+    "inputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "value_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "get",
+    "inputs": [
+      {
+        "name": "keys_",
+        "type": "string[]",
+        "internalType": "string[]"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "values_",
+        "type": "bytes32[]",
+        "internalType": "bytes32[]"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "implementation",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "implementation_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [
+      {
+        "name": "admins_",
+        "type": "address[]",
+        "internalType": "address[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "isAdmin",
+    "inputs": [
+      {
+        "name": "account_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "isAdmin_",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "migrate",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "migratorParameterKey",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "stateMutability": "pure"
+  },
+  {
+    "type": "function",
+    "name": "set",
+    "inputs": [
+      {
+        "name": "key_",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "value_",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "set",
+    "inputs": [
+      {
+        "name": "keys_",
+        "type": "string[]",
+        "internalType": "string[]"
+      },
+      {
+        "name": "values_",
+        "type": "bytes32[]",
+        "internalType": "bytes32[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Migrated",
+    "inputs": [
+      {
+        "name": "migrator",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ParameterSet",
+    "inputs": [
+      {
+        "name": "key",
+        "type": "string",
+        "indexed": true,
+        "internalType": "string"
+      },
+      {
+        "name": "value",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Upgraded",
+    "inputs": [
+      {
         "name": "implementation",
-        "inputs": [],
-        "outputs": [{ "name": "implementation_", "type": "address", "internalType": "address" }],
-        "stateMutability": "view"
-    },
-    {
-        "type": "function",
-        "name": "initialize",
-        "inputs": [{ "name": "admins_", "type": "address[]", "internalType": "address[]" }],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "isAdmin",
-        "inputs": [{ "name": "account_", "type": "address", "internalType": "address" }],
-        "outputs": [{ "name": "isAdmin_", "type": "bool", "internalType": "bool" }],
-        "stateMutability": "view"
-    },
-    { "type": "function", "name": "migrate", "inputs": [], "outputs": [], "stateMutability": "nonpayable" },
-    {
-        "type": "function",
-        "name": "migratorParameterKey",
-        "inputs": [],
-        "outputs": [{ "name": "key_", "type": "string", "internalType": "string" }],
-        "stateMutability": "pure"
-    },
-    {
-        "type": "function",
-        "name": "set",
-        "inputs": [
-            { "name": "key_", "type": "string", "internalType": "string" },
-            { "name": "value_", "type": "bytes32", "internalType": "bytes32" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "function",
-        "name": "set",
-        "inputs": [
-            { "name": "keys_", "type": "string[]", "internalType": "string[]" },
-            { "name": "values_", "type": "bytes32[]", "internalType": "bytes32[]" }
-        ],
-        "outputs": [],
-        "stateMutability": "nonpayable"
-    },
-    {
-        "type": "event",
-        "name": "Initialized",
-        "inputs": [{ "name": "version", "type": "uint64", "indexed": false, "internalType": "uint64" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Migrated",
-        "inputs": [{ "name": "migrator", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "ParameterSet",
-        "inputs": [
-            { "name": "key", "type": "string", "indexed": true, "internalType": "string" },
-            { "name": "value", "type": "bytes32", "indexed": true, "internalType": "bytes32" }
-        ],
-        "anonymous": false
-    },
-    {
-        "type": "event",
-        "name": "Upgraded",
-        "inputs": [{ "name": "implementation", "type": "address", "indexed": true, "internalType": "address" }],
-        "anonymous": false
-    },
-    { "type": "error", "name": "ArrayLengthMismatch", "inputs": [] },
-    { "type": "error", "name": "EmptyAdmins", "inputs": [] },
-    {
-        "type": "error",
-        "name": "EmptyCode",
-        "inputs": [{ "name": "migrator_", "type": "address", "internalType": "address" }]
-    },
-    { "type": "error", "name": "InvalidInitialization", "inputs": [] },
-    {
-        "type": "error",
-        "name": "MigrationFailed",
-        "inputs": [
-            { "name": "migrator_", "type": "address", "internalType": "address" },
-            { "name": "revertData_", "type": "bytes", "internalType": "bytes" }
-        ]
-    },
-    { "type": "error", "name": "NoKeyComponents", "inputs": [] },
-    { "type": "error", "name": "NoKeys", "inputs": [] },
-    { "type": "error", "name": "NotAdmin", "inputs": [] },
-    { "type": "error", "name": "NotInitializing", "inputs": [] },
-    { "type": "error", "name": "ParameterOutOfTypeBounds", "inputs": [] },
-    {
-        "type": "error",
-        "name": "StringsInsufficientHexLength",
-        "inputs": [
-            { "name": "value", "type": "uint256", "internalType": "uint256" },
-            { "name": "length", "type": "uint256", "internalType": "uint256" }
-        ]
-    },
-    { "type": "error", "name": "ZeroAdmin", "inputs": [] },
-    { "type": "error", "name": "ZeroMigrator", "inputs": [] }
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "ArrayLengthMismatch",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "EmptyAdmins",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "EmptyCode",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "InvalidInitialization",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "MigrationFailed",
+    "inputs": [
+      {
+        "name": "migrator_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "revertData_",
+        "type": "bytes",
+        "internalType": "bytes"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "NoKeyComponents",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NoKeys",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotAdmin",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ParameterOutOfTypeBounds",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "StringsInsufficientHexLength",
+    "inputs": [
+      {
+        "name": "value",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "length",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
+    "type": "error",
+    "name": "ZeroAdmin",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroMigrator",
+    "inputs": []
+  }
 ]

--- a/settlement-chain/package.json
+++ b/settlement-chain/package.json
@@ -8,8 +8,8 @@
         "codegen:testnet": "graph codegen testnet.yaml",
         "build:testnet-staging": "graph build testnet-staging.yaml",
         "build:testnet": "graph build testnet.yaml",
-        "deploy:testnet-staging": "graph deploy settlement-chain-testnet-staging testnet-staging.yaml --ipfs https://ipfs.satsuma.xyz --version-label $(grep VERSION_LABEL .env | cut -d '=' -f2) --node https://subgraphs.alchemy.com/api/subgraphs/deploy --deploy-key $(grep DEPLOY_KEY .env | cut -d '=' -f2)",
-        "deploy:testnet": "graph deploy settlement-chain-testnet testnet.yaml --ipfs https://ipfs.satsuma.xyz --version-label $(grep VERSION_LABEL .env | cut -d '=' -f2) --node https://subgraphs.alchemy.com/api/subgraphs/deploy --deploy-key $(grep DEPLOY_KEY .env | cut -d '=' -f2)",
+        "deploy:testnet-staging": "goldsky subgraph deploy settlement-chain-testnet-staging/$(grep VERSION_LABEL .env | cut -d '=' -f2) --path ./build --token $(grep GOLDSKY .env | cut -d '=' -f2) && goldsky subgraph tag create settlement-chain-testnet-staging/$(grep VERSION_LABEL .env | cut -d '=' -f2) --tag stable --token $(grep GOLDSKY .env | cut -d '=' -f2)",
+        "deploy:testnet": "goldsky subgraph deploy settlement-chain-testnet/$(grep VERSION_LABEL .env | cut -d '=' -f2) --path ./build --token $(grep GOLDSKY .env | cut -d '=' -f2) && goldsky subgraph tag create settlement-chain-testnet/$(grep VERSION_LABEL .env | cut -d '=' -f2) --tag stable --token $(grep GOLDSKY .env | cut -d '=' -f2)",
         "create-local": "graph create --node http://localhost:8020/ xmtp/settlement-chain",
         "remove-local": "graph remove --node http://localhost:8020/ xmtp/settlement-chain",
         "deploy-local": "graph deploy --node http://localhost:8020/ xmtp/settlement-chain",
@@ -18,6 +18,7 @@
     },
     "dependencies": {},
     "devDependencies": {
+        "@goldskycom/cli": "^3.1.0",
         "@graphprotocol/graph-cli": "^0.97.1",
         "@graphprotocol/graph-ts": "^0.38.1",
         "dotenv": "^16.5.0",

--- a/settlement-chain/schema.graphql
+++ b/settlement-chain/schema.graphql
@@ -35,6 +35,54 @@ interface BooleanSnapshotEntity implements SnapshotEntity {
     value: Boolean!
 }
 
+# ============ Daily Time Series - Interface ============ #
+
+interface DailyTimeSeriesEntity {
+    id: ID! @unique
+    date: String! @index          # YYYY-MM-DD format
+    dateTimestamp: Timestamp! @index  # Midnight UTC timestamp
+}
+
+# ============ Payer - Daily Time Series ============ #
+
+type DailyPayerUsage implements DailyTimeSeriesEntity @entity(immutable: false) {
+    id: ID! @unique                      # Format: DailyPayerUsage-{payerAddress}-{YYYY-MM-DD}
+    date: String! @index                 # YYYY-MM-DD
+    dateTimestamp: Timestamp! @index     # Midnight UTC timestamp
+    payer: Payer! @index
+
+    # Daily deltas (NOT cumulative)
+    feesSettled: BigInt!                 # Total fees settled this day
+    deposited: BigInt!                   # Total deposited this day
+    withdrawn: BigInt!                   # Total withdrawn this day
+    incurredDebt: BigInt!                # Debt incurred this day
+    repaidDebt: BigInt!                  # Debt repaid this day
+
+    # Metadata
+    eventCount: Int!                     # Number of events this day
+    lastUpdatedBlock: BigInt!            # Last block that updated this entity
+}
+
+# ============ Global - Daily Time Series ============ #
+
+type DailyRegistryUsage implements DailyTimeSeriesEntity @entity(immutable: false) {
+    id: ID! @unique                      # Format: DailyRegistryUsage-{YYYY-MM-DD}
+    date: String! @index                 # YYYY-MM-DD
+    dateTimestamp: Timestamp! @index     # Midnight UTC timestamp
+
+    # Daily deltas (NOT cumulative)
+    totalDeposited: BigInt!              # Total deposited across all payers this day
+    totalWithdrawn: BigInt!              # Total withdrawn across all payers this day
+    totalUsageSettled: BigInt!           # Total usage settled across all payers this day
+    totalIncurredDebt: BigInt!           # Total debt incurred this day
+    totalRepaidDebt: BigInt!             # Total debt repaid this day
+    totalExcessTransferred: BigInt!      # Total excess transferred this day
+
+    # Metadata
+    eventCount: Int!                     # Total events this day
+    lastUpdatedBlock: BigInt!            # Last block that updated this entity
+}
+
 # ============ Payer - Snapshot Interfaces ============ #
 
 interface PayerSnapshotEntity implements SnapshotEntity {
@@ -161,6 +209,9 @@ type Payer @entity(immutable: false) {
     withdrawals: [PayerRegistryWithdrawal!] @derivedFrom(field: "payer")
     usageSettlements: [PayerRegistryUsageSettlement!] @derivedFrom(field: "payer")
     history: [History!] @derivedFrom(field: "payer")
+
+    # Daily Time Series
+    dailyUsage: [DailyPayerUsage!] @derivedFrom(field: "payer")
 }
 
 # ============ PayerRegistry - Snapshot Interfaces ============ #

--- a/settlement-chain/src/common.ts
+++ b/settlement-chain/src/common.ts
@@ -2,6 +2,9 @@ import { Address, BigInt, Timestamp, dataSource } from '@graphprotocol/graph-ts'
 
 import {
     Account,
+    DailyPayerUsage,
+    DailyRegistryUsage,
+    Payer,
     PayerRegistry,
     PayerRegistryExcessSnapshot,
     PayerRegistryTotalWithdrawableSnapshot,
@@ -125,4 +128,91 @@ export function _getExcess(payerRegistry: PayerRegistry): BigInt {
     return payerRegistryFeeTokenBalance.gt(payerRegistry.totalWithdrawable)
         ? payerRegistryFeeTokenBalance.minus(payerRegistry.totalWithdrawable)
         : BigInt.fromI32(0);
+}
+
+/* ============ Daily Time Series Helpers ============ */
+
+/**
+ * Converts a block timestamp (seconds since epoch) to a UTC date key (YYYY-MM-DD)
+ */
+export function getDateKey(timestamp: i32): string {
+    const SECONDS_PER_DAY = 86400;
+    const daysSinceEpoch = timestamp / SECONDS_PER_DAY;
+    const midnightTimestamp = daysSinceEpoch * SECONDS_PER_DAY;
+
+    // Convert to i64 before multiplying by 1000 to avoid i32 overflow
+    const date = new Date(i64(midnightTimestamp) * 1000);
+    const year = date.getUTCFullYear();
+    const month = date.getUTCMonth() + 1;
+    const day = date.getUTCDate();
+
+    const monthStr = month < 10 ? '0' + month.toString() : month.toString();
+    const dayStr = day < 10 ? '0' + day.toString() : day.toString();
+
+    return year.toString() + '-' + monthStr + '-' + dayStr;
+}
+
+/**
+ * Gets the midnight UTC timestamp for a given block timestamp
+ */
+export function getMidnightTimestamp(timestamp: i32): i32 {
+    const SECONDS_PER_DAY = 86400;
+    const daysSinceEpoch = timestamp / SECONDS_PER_DAY;
+    return daysSinceEpoch * SECONDS_PER_DAY;
+}
+
+/**
+ * Upserts a DailyPayerUsage entity for the given payer and timestamp
+ */
+export function upsertDailyPayerUsage(payer: Payer, timestamp: i32, blockNumber: BigInt): DailyPayerUsage {
+    const dateKey = getDateKey(timestamp);
+    const id = `DailyPayerUsage-${payer.address}-${dateKey}`;
+
+    let dailyUsage = DailyPayerUsage.load(id);
+
+    if (!dailyUsage) {
+        dailyUsage = new DailyPayerUsage(id);
+        dailyUsage.date = dateKey;
+        dailyUsage.dateTimestamp = getMidnightTimestamp(timestamp);
+        dailyUsage.payer = payer.id;
+
+        dailyUsage.feesSettled = BigInt.fromI32(0);
+        dailyUsage.deposited = BigInt.fromI32(0);
+        dailyUsage.withdrawn = BigInt.fromI32(0);
+        dailyUsage.incurredDebt = BigInt.fromI32(0);
+        dailyUsage.repaidDebt = BigInt.fromI32(0);
+        dailyUsage.eventCount = 0;
+    }
+
+    dailyUsage.lastUpdatedBlock = blockNumber;
+
+    return dailyUsage;
+}
+
+/**
+ * Upserts a DailyRegistryUsage entity for the given timestamp
+ */
+export function upsertDailyRegistryUsage(timestamp: i32, blockNumber: BigInt): DailyRegistryUsage {
+    const dateKey = getDateKey(timestamp);
+    const id = `DailyRegistryUsage-${dateKey}`;
+
+    let dailyUsage = DailyRegistryUsage.load(id);
+
+    if (!dailyUsage) {
+        dailyUsage = new DailyRegistryUsage(id);
+        dailyUsage.date = dateKey;
+        dailyUsage.dateTimestamp = getMidnightTimestamp(timestamp);
+
+        dailyUsage.totalDeposited = BigInt.fromI32(0);
+        dailyUsage.totalWithdrawn = BigInt.fromI32(0);
+        dailyUsage.totalUsageSettled = BigInt.fromI32(0);
+        dailyUsage.totalIncurredDebt = BigInt.fromI32(0);
+        dailyUsage.totalRepaidDebt = BigInt.fromI32(0);
+        dailyUsage.totalExcessTransferred = BigInt.fromI32(0);
+        dailyUsage.eventCount = 0;
+    }
+
+    dailyUsage.lastUpdatedBlock = blockNumber;
+
+    return dailyUsage;
 }

--- a/settlement-chain/src/payer-registry.ts
+++ b/settlement-chain/src/payer-registry.ts
@@ -48,7 +48,12 @@ import {
     Upgraded as UpgradedEvent,
 } from '../generated/PayerRegistry/PayerRegistry';
 
-import { getPayerRegistry, _updatePayerRegistryTotalWithdrawable } from './common';
+import {
+    getPayerRegistry,
+    upsertDailyPayerUsage,
+    upsertDailyRegistryUsage,
+    _updatePayerRegistryTotalWithdrawable,
+} from './common';
 
 /* ============ Handlers ============ */
 
@@ -59,6 +64,17 @@ export function handleDeposit(event: DepositEvent): void {
     const payer = getPayer(event.params.payer);
 
     _deposit(payerRegistry, payer, amount, timestamp);
+
+    // Update daily time series
+    const dailyPayerUsage = upsertDailyPayerUsage(payer, timestamp, event.block.number);
+    dailyPayerUsage.deposited = dailyPayerUsage.deposited.plus(amount);
+    dailyPayerUsage.eventCount += 1;
+    dailyPayerUsage.save();
+
+    const dailyRegistryUsage = upsertDailyRegistryUsage(timestamp, event.block.number);
+    dailyRegistryUsage.totalDeposited = dailyRegistryUsage.totalDeposited.plus(amount);
+    dailyRegistryUsage.eventCount += 1;
+    dailyRegistryUsage.save();
 
     payerRegistry.lastUpdate = timestamp;
     payerRegistry.save();
@@ -170,6 +186,17 @@ export function handleUsageSettled(event: UsageSettledEvent): void {
 
     _settleUsage(payerRegistry, payer, amount, timestamp);
 
+    // Update daily time series
+    const dailyPayerUsage = upsertDailyPayerUsage(payer, timestamp, event.block.number);
+    dailyPayerUsage.feesSettled = dailyPayerUsage.feesSettled.plus(amount);
+    dailyPayerUsage.eventCount += 1;
+    dailyPayerUsage.save();
+
+    const dailyRegistryUsage = upsertDailyRegistryUsage(timestamp, event.block.number);
+    dailyRegistryUsage.totalUsageSettled = dailyRegistryUsage.totalUsageSettled.plus(amount);
+    dailyRegistryUsage.eventCount += 1;
+    dailyRegistryUsage.save();
+
     payerRegistry.lastUpdate = timestamp;
     payerRegistry.save();
 
@@ -262,6 +289,17 @@ export function handleWithdrawalFinalized(event: WithdrawalFinalizedEvent): void
     if (!withdrawal) throw new Error('No pending withdrawal');
 
     _finalizeWithdrawal(payerRegistry, payer, withdrawal, timestamp);
+
+    // Update daily time series
+    const dailyPayerUsage = upsertDailyPayerUsage(payer, timestamp, event.block.number);
+    dailyPayerUsage.withdrawn = dailyPayerUsage.withdrawn.plus(withdrawal.amount);
+    dailyPayerUsage.eventCount += 1;
+    dailyPayerUsage.save();
+
+    const dailyRegistryUsage = upsertDailyRegistryUsage(timestamp, event.block.number);
+    dailyRegistryUsage.totalWithdrawn = dailyRegistryUsage.totalWithdrawn.plus(withdrawal.amount);
+    dailyRegistryUsage.eventCount += 1;
+    dailyRegistryUsage.save();
 
     payerRegistry.lastUpdate = timestamp;
     payerRegistry.save();

--- a/settlement-chain/testnet-staging.yaml
+++ b/settlement-chain/testnet-staging.yaml
@@ -113,7 +113,7 @@ dataSources:
       network: base-sepolia
       source:
           abi: PayerReportManager
-          address: '0x8644DB92F11fDeCBCBfB5F2Bb84a000f28F7B59c'
+          address: '0x868132030B97457582630456ACBe6bD303F17263'
           startBlock: 29155490
       mapping:
           kind: ethereum/events

--- a/settlement-chain/testnet-staging.yaml
+++ b/settlement-chain/testnet-staging.yaml
@@ -8,7 +8,7 @@ dataSources:
       source:
           abi: PayerRegistry
           address: '0x208E94fbC9833B58765fedC30CFF8539C6356e88'
-          startBlock: 26900619
+          startBlock: 29155490
       context:
           startingImplementation:
               type: String
@@ -67,7 +67,7 @@ dataSources:
                 handler: handlePauseStatusUpdated
               - event: SettlerUpdated(indexed address)
                 handler: handleSettlerUpdated
-              - event: UsageSettled(indexed address,uint96)
+              - event: UsageSettled(indexed bytes32,indexed address,uint96)
                 handler: handleUsageSettled
               - event: WithdrawLockPeriodUpdated(uint32)
                 handler: handleWithdrawLockPeriodUpdated
@@ -84,8 +84,8 @@ dataSources:
       source:
           abi: FeeToken
           address: '0x63C6667798fdA65E2E29228C43fbfDa0Cd4634A8'
-          startBlock: 26900619
-          endBlock: 26900619 # Remove this when this is FeeToken/xUSD.
+          startBlock: 29155490
+          endBlock: 29155490 # Remove this when this is FeeToken/xUSD.
       context:
           payerRegistry:
               type: String

--- a/settlement-chain/testnet.yaml
+++ b/settlement-chain/testnet.yaml
@@ -113,7 +113,7 @@ dataSources:
       network: base-sepolia
       source:
           abi: PayerReportManager
-          address: '0x9EC340209b54C661ceFF468B70fF8122ff9D009e'
+          address: '0x9de0b8C883c01F28A0F3d39De90c098F0941176f'
           startBlock: 29322114
       mapping:
           kind: ethereum/events
@@ -133,3 +133,43 @@ dataSources:
               - event: PayerReportSubsetSettled(indexed uint32,indexed uint256,uint32,uint32,uint96)
                 handler: handlePayerReportSubsetSettled
           file: ./src/payer-report-manager.ts
+    - kind: ethereum
+      name: SettlementChainGateway
+      network: base-sepolia
+      source:
+          abi: SettlementChainGateway
+          address: '0xB64D5bF62F30512Bd130C0D7c80DB7ac1e6801a3'
+          startBlock: 29322114
+      context:
+          startingImplementation:
+              type: String
+              data: '0xB64D5bF62F30512Bd130C0D7c80DB7ac1e6801a3'
+      mapping:
+          kind: ethereum/events
+          apiVersion: 0.0.9
+          language: wasm/assemblyscript
+          entities:
+              - History
+              - Account
+              - GatewayDeposit
+              - GatewayReceivedWithdrawal
+              - GatewayInbox
+              - ParameterSend
+              - SettlementChainGateway
+          abis:
+              - name: SettlementChainGateway
+                file: ./abis/SettlementChainGateway.abi.json
+          eventHandlers:
+              - event: Deposit(indexed uint256,indexed uint256,uint256)
+                handler: handleDeposit
+              - event: InboxUpdated(indexed uint256,indexed address)
+                handler: handleInboxUpdated
+              - event: ParametersSent(indexed uint256,indexed uint256,uint256,string[])
+                handler: handleParametersSent
+              - event: PauseStatusUpdated(indexed bool)
+                handler: handlePauseStatusUpdated
+              - event: WithdrawalReceived(indexed address,uint256)
+                handler: handleWithdrawalReceived
+              - event: Upgraded(indexed address)
+                handler: handleUpgraded
+          file: ./src/settlement-chain-gateway.ts

--- a/settlement-chain/testnet.yaml
+++ b/settlement-chain/testnet.yaml
@@ -8,7 +8,7 @@ dataSources:
       source:
           abi: PayerRegistry
           address: '0xF0bd6Ac8AA00BA083cF95C5438B33488cbd2562B'
-          startBlock: 26900619
+          startBlock: 29322100
       context:
           startingImplementation:
               type: String
@@ -67,7 +67,7 @@ dataSources:
                 handler: handlePauseStatusUpdated
               - event: SettlerUpdated(indexed address)
                 handler: handleSettlerUpdated
-              - event: UsageSettled(indexed address,uint96)
+              - event: UsageSettled(indexed bytes32,indexed address,uint96)
                 handler: handleUsageSettled
               - event: WithdrawLockPeriodUpdated(uint32)
                 handler: handleWithdrawLockPeriodUpdated
@@ -84,8 +84,8 @@ dataSources:
       source:
           abi: FeeToken
           address: '0x63C6667798fdA65E2E29228C43fbfDa0Cd4634A8'
-          startBlock: 26900619
-          endBlock: 26900619 # Remove this when this is FeeToken/xUSD.
+          startBlock: 29322100
+          endBlock: 29322100 # Remove this when this is FeeToken/xUSD.
       context:
           payerRegistry:
               type: String

--- a/settlement-chain/yarn.lock
+++ b/settlement-chain/yarn.lock
@@ -43,6 +43,16 @@
     graphql-import-node "^0.0.5"
     js-yaml "^4.1.0"
 
+"@goldskycom/cli@^3.1.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@goldskycom/cli/-/cli-3.2.0.tgz#9776f01a34f1c1c867dd6acdd12fd3695a543659"
+  integrity sha512-0ZTpE75rnfI0z0sZFvVpk9/i4dP7gWs/z4jQMcqWd6oPN+zofnuE/C18fIjOCmVm463wP6UN5kcnhpqC3fmMyg==
+  dependencies:
+    cuid "^2.1.8"
+    parse-duration "^1.0.3"
+    readline-sync "^1.4.10"
+    update-notifier "^6.0.2"
+
 "@graphprotocol/graph-cli@^0.97.1":
   version "0.97.1"
   resolved "https://registry.yarnpkg.com/@graphprotocol/graph-cli/-/graph-cli-0.97.1.tgz#a9130b813437b032aaf7857f2d75fc9f7c18f991"
@@ -524,6 +534,18 @@
     "@noble/hashes" "~1.4.0"
     "@scure/base" "~1.1.6"
 
+"@sindresorhus/is@^5.2.0":
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-5.6.0.tgz#41dd6093d34652cddb5d5bdeee04eafc33826668"
+  integrity sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==
+
+"@szmarczak/http-timer@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-5.0.1.tgz#c7c1bf1141cdd4751b0399c8fc7b8b664cd5be3a"
+  integrity sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==
+  dependencies:
+    defer-to-connect "^2.0.1"
+
 "@types/connect@^3.4.33":
   version "3.4.38"
   resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.38.tgz#5ba7f3bc4fbbdeaff8dded952e5ff2cc53f8d858"
@@ -537,6 +559,11 @@
   integrity sha512-qXOC7XLOEe43ehtWJCMnQXvgcIpv6rPmQ1jXT98Ad8A3TB1Ue50jsCbSSSyuazScEuZ/Q026vHbrOTVkmwA+7Q==
   dependencies:
     "@types/node" "*"
+
+"@types/http-cache-semantics@^4.0.2":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz#b979ebad3919799c979b17c72621c0bc0a31c6c4"
+  integrity sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==
 
 "@types/node@*":
   version "24.0.3"
@@ -604,6 +631,13 @@ abort-error@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/abort-error/-/abort-error-1.0.1.tgz#526c17caf2ac9eb1fab1ffdff18c5076157a324e"
   integrity sha512-fxqCblJiIPdSXIUrxI0PL+eJG49QdP9SQ70qtB65MVAoMr2rASlOyAbJFOylfB467F/f+5BCLJJq58RYi7mGfg==
+
+ansi-align@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-3.0.1.tgz#0cdf12e111ace773a86e9a1fad1225c43cb19a59"
+  integrity sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==
+  dependencies:
+    string-width "^4.1.0"
 
 ansi-colors@^4.1.1:
   version "4.1.3"
@@ -746,6 +780,20 @@ blob-to-it@^2.0.5:
   dependencies:
     browser-readablestream-to-it "^2.0.0"
 
+boxen@^7.0.0:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/boxen/-/boxen-7.1.1.tgz#f9ba525413c2fec9cdb88987d835c4f7cad9c8f4"
+  integrity sha512-2hCgjEmP8YLWQ130n2FerGv7rYpfBmnmp9Uy2Le1vge6X3gZIfSmEzP5QTDElFxcvVcXlEn8Aq6MU/PZygIOog==
+  dependencies:
+    ansi-align "^3.0.1"
+    camelcase "^7.0.1"
+    chalk "^5.2.0"
+    cli-boxes "^3.0.0"
+    string-width "^5.1.2"
+    type-fest "^2.13.0"
+    widest-line "^4.0.1"
+    wrap-ansi "^8.1.0"
+
 brace-expansion@^1.1.7:
   version "1.1.12"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.12.tgz#ab9b454466e5a8cc3a187beaad580412a9c5b843"
@@ -793,6 +841,24 @@ bundle-name@^4.1.0:
   dependencies:
     run-applescript "^7.0.0"
 
+cacheable-lookup@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz#3476a8215d046e5a3202a9209dd13fec1f933a27"
+  integrity sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==
+
+cacheable-request@^10.2.8:
+  version "10.2.14"
+  resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-10.2.14.tgz#eb915b665fda41b79652782df3f553449c406b9d"
+  integrity sha512-zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==
+  dependencies:
+    "@types/http-cache-semantics" "^4.0.2"
+    get-stream "^6.0.1"
+    http-cache-semantics "^4.1.1"
+    keyv "^4.5.3"
+    mimic-response "^4.0.0"
+    normalize-url "^8.0.0"
+    responselike "^3.0.0"
+
 call-bind-apply-helpers@^1.0.0, call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz#4b5428c222be985d79c3d82657479dbe0b59b2d6"
@@ -824,6 +890,11 @@ callsites@^3.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
+camelcase@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-7.0.1.tgz#f02e50af9fd7782bc8b88a3558c32fd3a388f048"
+  integrity sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==
+
 cborg@^4.0.0:
   version "4.2.12"
   resolved "https://registry.yarnpkg.com/cborg/-/cborg-4.2.12.tgz#2f9826773f559e436cb85a49c88fc1bb08bdc373"
@@ -846,6 +917,11 @@ chalk@^4.0.2:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@^5.0.1, chalk@^5.2.0:
+  version "5.6.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.6.2.tgz#b1238b6e23ea337af71c7f8a295db5af0c158aea"
+  integrity sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==
+
 chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
@@ -858,12 +934,22 @@ chokidar@4.0.3:
   dependencies:
     readdirp "^4.0.1"
 
+ci-info@^3.2.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.9.0.tgz#4279a62028a7b1f262f3473fc9605f5e218c59b4"
+  integrity sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==
+
 clean-stack@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-3.0.1.tgz#155bf0b2221bf5f4fba89528d24c5953f17fe3a8"
   integrity sha512-lR9wNiMRcVQjSB3a7xXGLuz4cr4wJuuXlaAEbRutGowQTmlp7R72/DOgN21e8jdwblMWl9UOJMJXarX94pzKdg==
   dependencies:
     escape-string-regexp "4.0.0"
+
+cli-boxes@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-3.0.0.tgz#71a10c716feeba005e4504f36329ef0b17cf3145"
+  integrity sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==
 
 cli-cursor@^3.1.0:
   version "3.1.0"
@@ -944,6 +1030,17 @@ config-chain@^1.1.11:
     ini "^1.3.4"
     proto-list "~1.2.1"
 
+configstore@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/configstore/-/configstore-6.0.0.tgz#49eca2ebc80983f77e09394a1a56e0aca8235566"
+  integrity sha512-cD31W1v3GqUlQvbBCGcXmd2Nj9SvLDOP1oQ0YFuLETufzSPaKp11rYBsSOm7rCsW3OnIRAFM3OxRhceaXNYHkA==
+  dependencies:
+    dot-prop "^6.0.1"
+    graceful-fs "^4.2.6"
+    unique-string "^3.0.0"
+    write-file-atomic "^3.0.3"
+    xdg-basedir "^5.0.1"
+
 content-type@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.5.tgz#8b773162656d1d1086784c8f23a54ce6d73d7918"
@@ -978,6 +1075,18 @@ cross-spawn@^7.0.3, cross-spawn@^7.0.6:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+crypto-random-string@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-4.0.0.tgz#5a3cc53d7dd86183df5da0312816ceeeb5bb1fc2"
+  integrity sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==
+  dependencies:
+    type-fest "^1.0.1"
+
+cuid@^2.1.8:
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/cuid/-/cuid-2.1.8.tgz#cbb88f954171e0d5747606c0139fb65c5101eac0"
+  integrity sha512-xiEMER6E7TlTPnDxrM4eRiC6TRgjNX9xzEZ5U/Se2YJKr7Mq4pJn/2XEHjl3STcSh96GmkHPcBXLES8M29wyyg==
+
 dag-jose@^5.0.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/dag-jose/-/dag-jose-5.1.1.tgz#02708321f14b6f43990e238010c73464916259a7"
@@ -992,6 +1101,18 @@ debug@4.4.1, debug@^4.1.1, debug@^4.4.0, debug@^4.4.1:
   integrity sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==
   dependencies:
     ms "^2.1.3"
+
+decompress-response@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-6.0.0.tgz#ca387612ddb7e104bd16d85aab00d5ecf09c66fc"
+  integrity sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==
+  dependencies:
+    mimic-response "^3.1.0"
+
+deep-extend@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
+  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 default-browser-id@^5.0.0:
   version "5.0.0"
@@ -1012,6 +1133,11 @@ defaults@^1.0.3:
   integrity sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==
   dependencies:
     clone "^1.0.2"
+
+defer-to-connect@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-2.0.1.tgz#8016bdb4143e4632b77a3449c6236277de520587"
+  integrity sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==
 
 define-data-property@^1.1.4:
   version "1.1.4"
@@ -1052,6 +1178,13 @@ docker-compose@1.2.0:
   integrity sha512-wIU1eHk3Op7dFgELRdmOYlPYS4gP8HhH1ZmZa13QZF59y0fblzFDFmKPhyc05phCy2hze9OEvNZAsoljrs+72w==
   dependencies:
     yaml "^2.2.2"
+
+dot-prop@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-6.0.1.tgz#fc26b3cf142b9e59b74dbd39ed66ce620c681083"
+  integrity sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==
+  dependencies:
+    is-obj "^2.0.0"
 
 dotenv@^16.5.0:
   version "16.5.0"
@@ -1157,6 +1290,11 @@ es6-promisify@^5.0.0:
   integrity sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==
   dependencies:
     es6-promise "^4.0.3"
+
+escape-goat@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/escape-goat/-/escape-goat-4.0.0.tgz#9424820331b510b0666b98f7873fe11ac4aa8081"
+  integrity sha512-2Sd4ShcWxbx6OY1IHyla/CVNwvg7XwZVoXZHcSu9w9SReNP1EzzD5T8NWKIR38fIqEns9kDWKUQTXXAmlDrdPg==
 
 escape-string-regexp@4.0.0:
   version "4.0.0"
@@ -1286,6 +1424,11 @@ foreground-child@^3.1.0:
     cross-spawn "^7.0.6"
     signal-exit "^4.0.1"
 
+form-data-encoder@^2.1.2:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/form-data-encoder/-/form-data-encoder-2.1.4.tgz#261ea35d2a70d48d30ec7a9603130fa5515e9cd5"
+  integrity sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==
+
 fs-extra@11.3.0:
   version "11.3.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.3.0.tgz#0daced136bbaf65a555a326719af931adc7a314d"
@@ -1347,7 +1490,7 @@ get-proto@^1.0.0, get-proto@^1.0.1:
     dunder-proto "^1.0.1"
     es-object-atoms "^1.0.0"
 
-get-stream@^6.0.0:
+get-stream@^6.0.0, get-stream@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
@@ -1382,6 +1525,13 @@ glob@^7.1.3:
     minimatch "^3.1.1"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+global-dirs@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-3.0.1.tgz#0c488971f066baceda21447aecb1a8b911d22485"
+  integrity sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==
+  dependencies:
+    ini "2.0.0"
 
 globby@^11.1.0:
   version "11.1.0"
@@ -1436,12 +1586,29 @@ gopd@^1.0.1, gopd@^1.2.0:
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
   integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
 
+got@^12.1.0:
+  version "12.6.1"
+  resolved "https://registry.yarnpkg.com/got/-/got-12.6.1.tgz#8869560d1383353204b5a9435f782df9c091f549"
+  integrity sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ==
+  dependencies:
+    "@sindresorhus/is" "^5.2.0"
+    "@szmarczak/http-timer" "^5.0.1"
+    cacheable-lookup "^7.0.0"
+    cacheable-request "^10.2.8"
+    decompress-response "^6.0.0"
+    form-data-encoder "^2.1.2"
+    get-stream "^6.0.1"
+    http2-wrapper "^2.1.10"
+    lowercase-keys "^3.0.0"
+    p-cancelable "^3.0.0"
+    responselike "^3.0.0"
+
 graceful-fs@4.2.10:
   version "4.2.10"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
-graceful-fs@^4.1.6, graceful-fs@^4.2.0:
+graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.6:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
@@ -1485,6 +1652,11 @@ has-tostringtag@^1.0.2:
   dependencies:
     has-symbols "^1.0.3"
 
+has-yarn@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-yarn/-/has-yarn-3.0.0.tgz#c3c21e559730d1d3b57e28af1f30d06fac38147d"
+  integrity sha512-IrsVwUHhEULx3R8f/aA8AHuEzAorplsab/v8HBzEiIukwq5i/EC+xmOW+HfP1OaDP+2JkgT1yILHN2O3UFIbcA==
+
 hashlru@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/hashlru/-/hashlru-2.3.0.tgz#5dc15928b3f6961a2056416bb3a4910216fdfb51"
@@ -1497,6 +1669,11 @@ hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
+http-cache-semantics@^4.1.1:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz#205f4db64f8562b76a4ff9235aa5279839a09dd5"
+  integrity sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==
+
 http-call@^5.2.2:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/http-call/-/http-call-5.3.0.tgz#4ded815b13f423de176eb0942d69c43b25b148db"
@@ -1508,6 +1685,14 @@ http-call@^5.2.2:
     is-stream "^2.0.0"
     parse-json "^4.0.0"
     tunnel-agent "^0.6.0"
+
+http2-wrapper@^2.1.10:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/http2-wrapper/-/http2-wrapper-2.2.1.tgz#310968153dcdedb160d8b72114363ef5fce1f64a"
+  integrity sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==
+  dependencies:
+    quick-lru "^5.1.1"
+    resolve-alpn "^1.2.0"
 
 human-signals@^2.1.0:
   version "2.1.0"
@@ -1551,6 +1736,16 @@ import-fresh@^3.2.1:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
 
+import-lazy@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-4.0.0.tgz#e8eb627483a0a43da3c03f3e35548be5cb0cc153"
+  integrity sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==
+
+imurmurhash@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
+  integrity sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
+
 indent-string@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
@@ -1569,7 +1764,12 @@ inherits@2, inherits@^2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
-ini@^1.3.4:
+ini@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-2.0.0.tgz#e5fd556ecdd5726be978fa1001862eacb0a94bc5"
+  integrity sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==
+
+ini@^1.3.4, ini@~1.3.0:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
@@ -1612,6 +1812,13 @@ is-callable@^1.2.7:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.7.tgz#3bc2a85ea742d9e36205dcacdd72ca1fdc51b055"
   integrity sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==
+
+is-ci@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-3.0.1.tgz#db6ecbed1bd659c43dac0f45661e7674103d1867"
+  integrity sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==
+  dependencies:
+    ci-info "^3.2.0"
 
 is-docker@^2.0.0:
   version "2.2.1"
@@ -1662,15 +1869,38 @@ is-inside-container@^1.0.0:
   dependencies:
     is-docker "^3.0.0"
 
+is-installed-globally@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/is-installed-globally/-/is-installed-globally-0.4.0.tgz#9a0fd407949c30f86eb6959ef1b7994ed0b7b520"
+  integrity sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==
+  dependencies:
+    global-dirs "^3.0.0"
+    is-path-inside "^3.0.2"
+
 is-interactive@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-interactive/-/is-interactive-1.0.0.tgz#cea6e6ae5c870a7b0a0004070b7b587e0252912e"
   integrity sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==
 
+is-npm@^6.0.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-6.1.0.tgz#f70e0b6c132dfc817ac97d3badc0134945b098d3"
+  integrity sha512-O2z4/kNgyjhQwVR1Wpkbfc19JIhggF97NZNCpWTnjH7kVcZMUrnut9XSN7txI7VdyIYk5ZatOq3zvSuWpU8hoA==
+
 is-number@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
+
+is-obj@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-2.0.0.tgz#473fb05d973705e3fd9620545018ca8e22ef4982"
+  integrity sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==
+
+is-path-inside@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.3.tgz#d231362e53a07ff2b0e0ea7fed049161ffd16283"
+  integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
 
 is-plain-obj@^2.1.0:
   version "2.1.0"
@@ -1704,6 +1934,11 @@ is-typed-array@^1.1.3:
   dependencies:
     which-typed-array "^1.1.16"
 
+is-typedarray@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
+  integrity sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==
+
 is-wsl@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
@@ -1717,6 +1952,11 @@ is-wsl@^3.1.0:
   integrity sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==
   dependencies:
     is-inside-container "^1.0.0"
+
+is-yarn-global@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/is-yarn-global/-/is-yarn-global-0.4.1.tgz#b312d902b313f81e4eaf98b6361ba2b45cd694bb"
+  integrity sha512-/kppl+R+LO5VmhYSEWARUFjodS25D68gvj8W7z0I7OWhUla5xWu8KL6CtB2V0R6yqhnRgbcaREMr4EEM6htLPQ==
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -1838,6 +2078,11 @@ js-yaml@4.1.0, js-yaml@^4.1.0:
   dependencies:
     argparse "^2.0.1"
 
+json-buffer@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"
+  integrity sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==
+
 json-parse-better-errors@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
@@ -1861,6 +2106,13 @@ jsonfile@^6.0.1:
     universalify "^2.0.0"
   optionalDependencies:
     graceful-fs "^4.1.6"
+
+keyv@^4.5.3:
+  version "4.5.4"
+  resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.5.4.tgz#a879a99e29452f942439f2a405e3af8b31d4de93"
+  integrity sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==
+  dependencies:
+    json-buffer "3.0.1"
 
 kubo-rpc-client@^5.0.2:
   version "5.2.0"
@@ -1900,6 +2152,13 @@ kubo-rpc-client@^5.0.2:
     stream-to-it "^1.0.1"
     uint8arrays "^5.0.3"
     wherearewe "^2.0.1"
+
+latest-version@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-7.0.0.tgz#843201591ea81a4d404932eeb61240fe04e9e5da"
+  integrity sha512-KvNT4XqAMzdcL6ka6Tl3i2lYeFDgXNCuIX+xNx6ZMVR1dFq+idXd9FLKNMOIx0t9mJ9/HudyX4oZWXZQ0UJHeg==
+  dependencies:
+    package-json "^8.1.0"
 
 lilconfig@^3.1.3:
   version "3.1.3"
@@ -2003,6 +2262,11 @@ long@^5.2.0, long@^5.2.1:
   resolved "https://registry.yarnpkg.com/long/-/long-5.3.2.tgz#1d84463095999262d7d7b7f8bfd4a8cc55167f83"
   integrity sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==
 
+lowercase-keys@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-3.0.0.tgz#c5e7d442e37ead247ae9db117a9d0a467c89d4f2"
+  integrity sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==
+
 lru-cache@^11.0.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-11.1.0.tgz#afafb060607108132dbc1cf8ae661afb69486117"
@@ -2055,6 +2319,16 @@ mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
+mimic-response@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-3.1.0.tgz#2d1d59af9c1b129815accc2c46a022a5ce1fa3c9"
+  integrity sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
+
+mimic-response@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-4.0.0.tgz#35468b19e7c75d10f5165ea25e75a5ceea7cf70f"
+  integrity sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==
+
 minimatch@^10.0.0:
   version "10.0.3"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.0.3.tgz#cf7a0314a16c4d9ab73a7730a0e8e3c3502d47aa"
@@ -2082,6 +2356,11 @@ minimatch@^9.0.5:
   integrity sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==
   dependencies:
     brace-expansion "^2.0.1"
+
+minimist@^1.2.0:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
+  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
 minipass@^7.1.2:
   version "7.1.2"
@@ -2122,6 +2401,11 @@ native-fetch@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/native-fetch/-/native-fetch-4.0.2.tgz#75c8a44c5f3bb021713e5e24f2846750883e49af"
   integrity sha512-4QcVlKFtv2EYVS5MBgsGX5+NWKtbDbIECdUXDBGDMAZXq3Jkv9zf+y8iS7Ub8fEdga3GpYeazp9gauNqXHJOCg==
+
+normalize-url@^8.0.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-8.1.0.tgz#d33504f67970decf612946fd4880bc8c0983486d"
+  integrity sha512-X06Mfd/5aKsRHc0O0J5CUedwnPmnDtLF2+nq+KN9KSDlJHkPuh0JUviWjEWMe0SW/9TDdSLVPuk7L5gGTIA1/w==
 
 npm-run-path@^4.0.1:
   version "4.0.1"
@@ -2177,6 +2461,11 @@ os-tmpdir@~1.0.2:
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==
 
+p-cancelable@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-3.0.0.tgz#63826694b54d61ca1c20ebcb6d3ecf5e14cd8050"
+  integrity sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==
+
 p-defer@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-3.0.0.tgz#d1dceb4ee9b2b604b1d94ffec83760175d4e6f83"
@@ -2213,12 +2502,27 @@ package-json-from-dist@^1.0.0:
   resolved "https://registry.yarnpkg.com/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz#4f1471a010827a86f94cfd9b0727e36d267de505"
   integrity sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==
 
+package-json@^8.1.0:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/package-json/-/package-json-8.1.1.tgz#3e9948e43df40d1e8e78a85485f1070bf8f03dc8"
+  integrity sha512-cbH9IAIJHNj9uXi196JVsRlt7cHKak6u/e6AkL/bkRelZ7rlL3X1YKxsZwa36xipOEKAsdtmaG6aAJoM1fx2zA==
+  dependencies:
+    got "^12.1.0"
+    registry-auth-token "^5.0.1"
+    registry-url "^6.0.0"
+    semver "^7.3.7"
+
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
   integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
   dependencies:
     callsites "^3.0.0"
+
+parse-duration@^1.0.3:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/parse-duration/-/parse-duration-1.1.2.tgz#20008e6c507814761864669bb936e3f4a9a80758"
+  integrity sha512-p8EIONG8L0u7f8GFgfVlL4n8rnChTt8O5FSxgxMz2tjc9FMP199wxVKVB6IbKx11uTbKHACSvaLVIKNnoeNR/A==
 
 parse-duration@^2.1.2:
   version "2.1.4"
@@ -2315,10 +2619,32 @@ protons-runtime@^5.5.0:
     uint8arraylist "^2.4.3"
     uint8arrays "^5.0.1"
 
+pupa@^3.1.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/pupa/-/pupa-3.3.0.tgz#bc4036f9e8920c08ad472bc18fb600067cb83810"
+  integrity sha512-LjgDO2zPtoXP2wJpDjZrGdojii1uqO0cnwKoIoUzkfS98HDmbeiGmYiXo3lXeFlq2xvne1QFQhwYXSUCLKtEuA==
+  dependencies:
+    escape-goat "^4.0.0"
+
 queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
+
+quick-lru@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.1.tgz#366493e6b3e42a3a6885e2e99d18f80fb7a8c932"
+  integrity sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==
+
+rc@1.2.8:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
+  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
+  dependencies:
+    deep-extend "^0.6.0"
+    ini "~1.3.0"
+    minimist "^1.2.0"
+    strip-json-comments "~2.0.1"
 
 react-native-fetch-api@^3.0.0:
   version "3.0.0"
@@ -2341,17 +2667,41 @@ readdirp@^4.0.1:
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-4.1.2.tgz#eb85801435fbf2a7ee58f19e0921b068fc69948d"
   integrity sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==
 
-registry-auth-token@^5.1.0:
+readline-sync@^1.4.10:
+  version "1.4.10"
+  resolved "https://registry.yarnpkg.com/readline-sync/-/readline-sync-1.4.10.tgz#41df7fbb4b6312d673011594145705bf56d8873b"
+  integrity sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==
+
+registry-auth-token@^5.0.1, registry-auth-token@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-5.1.0.tgz#3c659047ecd4caebd25bc1570a3aa979ae490eca"
   integrity sha512-GdekYuwLXLxMuFTwAPg5UKGLW/UXzQrZvH/Zj791BQif5T05T0RsaLfHc9q3ZOKi7n+BoprPD9mJ0O0k4xzUlw==
   dependencies:
     "@pnpm/npm-conf" "^2.1.0"
 
+registry-url@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/registry-url/-/registry-url-6.0.1.tgz#056d9343680f2f64400032b1e199faa692286c58"
+  integrity sha512-+crtS5QjFRqFCoQmvGduwYWEBng99ZvmFvF+cUJkGYF1L1BfU8C6Zp9T7f5vPAwyLkUExpvK+ANVZmGU49qi4Q==
+  dependencies:
+    rc "1.2.8"
+
+resolve-alpn@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/resolve-alpn/-/resolve-alpn-1.2.1.tgz#b7adbdac3546aaaec20b45e7d8265927072726f9"
+  integrity sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==
+
 resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
+
+responselike@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/responselike/-/responselike-3.0.0.tgz#20decb6c298aff0dbee1c355ca95461d42823626"
+  integrity sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==
+  dependencies:
+    lowercase-keys "^3.0.0"
 
 restore-cursor@^3.1.0:
   version "3.1.0"
@@ -2404,6 +2754,13 @@ safe-regex-test@^1.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
+semver-diff@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/semver-diff/-/semver-diff-4.0.0.tgz#3afcf5ed6d62259f5c72d0d5d50dffbdc9680df5"
+  integrity sha512-0Ju4+6A8iOnpL/Thra7dZsSlOHYAHIeMxfhWQRI1/VLcT3WDBZKKtQt/QkBOsiIN9ZpuvHE6cGZ0x4glCMmfiA==
+  dependencies:
+    semver "^7.3.5"
+
 semver@7.3.5:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
@@ -2415,6 +2772,11 @@ semver@7.7.2, semver@^7.6.3:
   version "7.7.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.2.tgz#67d99fdcd35cec21e6f8b87a7fd515a33f982b58"
   integrity sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==
+
+semver@^7.3.5, semver@^7.3.7:
+  version "7.7.3"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.3.tgz#4b5f4143d007633a8dc671cd0a6ef9147b8bb946"
+  integrity sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==
 
 set-function-length@^1.2.2:
   version "1.2.2"
@@ -2487,16 +2849,7 @@ stream-to-it@^1.0.1:
   dependencies:
     it-stream-types "^2.0.1"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -2521,7 +2874,7 @@ string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.2.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -2535,13 +2888,6 @@ strip-ansi@^5.2.0:
   dependencies:
     ansi-regex "^4.1.0"
 
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
 strip-ansi@^7.0.1:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.1.0.tgz#d5b6568ca689d8561370b0707685d22434faff45"
@@ -2553,6 +2899,11 @@ strip-final-newline@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
+
+strip-json-comments@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
+  integrity sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==
 
 supports-color@^5.3.0:
   version "5.5.0"
@@ -2631,6 +2982,23 @@ type-fest@^0.21.3:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
+type-fest@^1.0.1:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-1.4.0.tgz#e9fb813fe3bf1744ec359d55d1affefa76f14be1"
+  integrity sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==
+
+type-fest@^2.13.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.19.0.tgz#88068015bb33036a598b952e55e9311a60fd3a9b"
+  integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
+
+typedarray-to-buffer@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
+  integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
+  dependencies:
+    is-typedarray "^1.0.0"
+
 uint8-varint@^2.0.1, uint8-varint@^2.0.2:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/uint8-varint/-/uint8-varint-2.0.4.tgz#85be52b3849eb30f2c3640a2df8a14364180affb"
@@ -2663,10 +3031,37 @@ undici@7.9.0:
   resolved "https://registry.yarnpkg.com/undici/-/undici-7.9.0.tgz#09266190e9281cb049ba79ca6a5ec9372175dfd9"
   integrity sha512-e696y354tf5cFZPXsF26Yg+5M63+5H3oE6Vtkh2oqbvsE2Oe7s2nIbcQh5lmG7Lp/eS29vJtTpw9+p6PX0qNSg==
 
+unique-string@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-3.0.0.tgz#84a1c377aff5fd7a8bc6b55d8244b2bd90d75b9a"
+  integrity sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==
+  dependencies:
+    crypto-random-string "^4.0.0"
+
 universalify@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.1.tgz#168efc2180964e6386d061e094df61afe239b18d"
   integrity sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==
+
+update-notifier@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-6.0.2.tgz#a6990253dfe6d5a02bd04fbb6a61543f55026b60"
+  integrity sha512-EDxhTEVPZZRLWYcJ4ZXjGFN0oP7qYvbXWzEgRm/Yql4dHX5wDbvh89YHP6PK1lzZJYrMtXUuZZz8XGK+U6U1og==
+  dependencies:
+    boxen "^7.0.0"
+    chalk "^5.0.1"
+    configstore "^6.0.0"
+    has-yarn "^3.0.0"
+    import-lazy "^4.0.0"
+    is-ci "^3.0.1"
+    is-installed-globally "^0.4.0"
+    is-npm "^6.0.0"
+    is-yarn-global "^0.4.0"
+    latest-version "^7.0.0"
+    pupa "^3.1.0"
+    semver "^7.3.7"
+    semver-diff "^4.0.0"
+    xdg-basedir "^5.1.0"
 
 urlpattern-polyfill@^10.0.0:
   version "10.1.0"
@@ -2788,12 +3183,19 @@ widest-line@^3.1.0:
   dependencies:
     string-width "^4.0.0"
 
+widest-line@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/widest-line/-/widest-line-4.0.1.tgz#a0fc673aaba1ea6f0a0d35b3c2795c9a9cc2ebf2"
+  integrity sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==
+  dependencies:
+    string-width "^5.0.1"
+
 wordwrap@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -2806,15 +3208,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
@@ -2834,10 +3227,25 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
+write-file-atomic@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-3.0.3.tgz#56bd5c5a5c70481cd19c571bd39ab965a5de56e8"
+  integrity sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==
+  dependencies:
+    imurmurhash "^0.1.4"
+    is-typedarray "^1.0.0"
+    signal-exit "^3.0.2"
+    typedarray-to-buffer "^3.1.5"
+
 ws@^7.5.10:
   version "7.5.10"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.10.tgz#58b5c20dc281633f6c19113f39b349bd8bd558d9"
   integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
+
+xdg-basedir@^5.0.1, xdg-basedir@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-5.1.0.tgz#1efba19425e73be1bc6f2a6ceb52a3d2c884c0c9"
+  integrity sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==
 
 yallist@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Promote Testnet Staging to Testnet by adding daily usage entities and handlers, updating event signatures to `UsageSettled(indexed bytes32,indexed address,uint96)`, and indexing `SettlementChainGateway` on base-sepolia starting at block 29322114
Add daily time-series entities and upsert utilities for account, payer, and registry usage; update handlers to record per-day metrics; change `UsageSettled` event shape; add a new `SettlementChainGateway` data source; refresh ABIs and deployment configs; and add Goldsky CLI support and docs. Key files: [app-chain/src/group-message-broadcaster.ts](https://github.com/xmtp/subgraphs/pull/17/files#diff-bd736b16c97d744b507ea747b66ed8a7bd8d265db7e3c618ea1ac24b32c702d9), [app-chain/src/identity-update-broadcaster.ts](https://github.com/xmtp/subgraphs/pull/17/files#diff-da81329180d15a1d6546f695fd1dedf764be1b38006aacf6441e6a4d9d1ca369), [settlement-chain/src/payer-registry.ts](https://github.com/xmtp/subgraphs/pull/17/files#diff-fd5f4a371019d641696766fb0501bb4d43666af03e88126dd6c7463a102df71f), [settlement-chain/testnet.yaml](https://github.com/xmtp/subgraphs/pull/17/files#diff-df843975ba8c4db8c1c0ad029e09568d88e92f0e8c7d5563e7f791cc52f4406d), [app-chain/schema.graphql](https://github.com/xmtp/subgraphs/pull/17/files#diff-a2ff6d7779bc0b445d1370619f2358d91ff8a9f8acdd17e55440e86d23bb063b), [settlement-chain/schema.graphql](https://github.com/xmtp/subgraphs/pull/17/files#diff-bc46dfdf4ef0a6b311cadfed862736a57c8cdbd0d44650fd30ca8a435e514960).

#### 📍Where to Start
Start with the daily upsert utilities in [app-chain/src/common.ts](https://github.com/xmtp/subgraphs/pull/17/files#diff-ef8a39c45700a5f8e8e5c216711e81fe648bb738943504fa33fa8845bc952ec9) and [settlement-chain/src/common.ts](https://github.com/xmtp/subgraphs/pull/17/files#diff-9bf725cd0418bfbcd2c46a5d9d604b2e91b856b67f75c1718ab64c7575d6684c), then review their use in event handlers: [app-chain/src/group-message-broadcaster.ts](https://github.com/xmtp/subgraphs/pull/17/files#diff-bd736b16c97d744b507ea747b66ed8a7bd8d265db7e3c618ea1ac24b32c702d9), [app-chain/src/identity-update-broadcaster.ts](https://github.com/xmtp/subgraphs/pull/17/files#diff-da81329180d15a1d6546f695fd1dedf764be1b38006aacf6441e6a4d9d1ca369), and [settlement-chain/src/payer-registry.ts](https://github.com/xmtp/subgraphs/pull/17/files#diff-fd5f4a371019d641696766fb0501bb4d43666af03e88126dd6c7463a102df71f).

----
<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 967ad7e. 5 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>

### 🗂️ Filtered Issues

</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->