### PR TITLE
docs: fix Goldsky/Alchemy documentation mismatch

### DIFF
--- a/GITFLOW.md
+++ b/GITFLOW.md
@@ -4,7 +4,7 @@ This document describes the branch-based deployment strategy for the subgraphs p
 
 ## Overview
 
-The subgraphs repository uses a **branch-based deployment flow** that corresponds to smart contract environments and frontend deployments. Each branch deploys to a specific subgraph instance on Alchemy/Satsuma.
+The subgraphs repository uses a **branch-based deployment flow** that corresponds to smart contract environments and frontend deployments. Each branch deploys to a specific subgraph instance on Goldsky.
 
 ## Branch Structure
 
@@ -250,22 +250,23 @@ Always increment version when deploying to the same environment to avoid "versio
 
 ## Subgraph Endpoints
 
+Deployments currently target **Goldsky** (see `CLAUDE.md` for full endpoint and project details).
+
 ### Testnet-Staging
 
-- **App Chain**: `https://subgraph.satsuma-prod.com/a046fea75687/ephemerahq/app-chain-testnet-staging/api`
-- **Settlement Chain**: `https://subgraph.satsuma-prod.com/a046fea75687/ephemerahq/settlement-chain-testnet-staging/api`
+- **App Chain**: `https://api.goldsky.com/api/public/project_cmh3prjsr002wr4p22cdshlhh/subgraphs/app-chain-testnet-staging/stable/gn`
+- **Settlement Chain**: `https://api.goldsky.com/api/public/project_cmh3prjsr002wr4p22cdshlhh/subgraphs/settlement-chain-testnet-staging/stable/gn`
 
 ### Testnet (Production Testnet)
 
-- **App Chain**: `https://subgraph.satsuma-prod.com/a046fea75687/ephemerahq/app-chain-testnet/api`
-- **Settlement Chain**: `https://subgraph.satsuma-prod.com/a046fea75687/ephemerahq/settlement-chain-testnet/api`
+- **App Chain**: `https://api.goldsky.com/api/public/project_cmh3prjsr002wr4p22cdshlhh/subgraphs/app-chain-testnet/stable/gn`
+- **Settlement Chain**: `https://api.goldsky.com/api/public/project_cmh3prjsr002wr4p22cdshlhh/subgraphs/settlement-chain-testnet/stable/gn`
 
 ### Mainnet (Production)
 
-- **App Chain**: `https://subgraph.satsuma-prod.com/a046fea75687/ephemerahq/app-chain-mainnet/api`
-- **Settlement Chain**: `https://subgraph.satsuma-prod.com/a046fea75687/ephemerahq/settlement-chain-mainnet/api`
+- Not yet deployed. Mainnet endpoints will follow the same Goldsky `/stable/gn` pattern once available.
 
-**Note**: Always use stable endpoints (without `/version/xxx`) for frontend integration.
+**Note**: Always use stable endpoints (`/stable/gn`, without a version number) for frontend integration.
 
 ## Common Commands Reference
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository contains subgraphs for event listening of XMTP smart contracts r
 -   **[The Graph Protocol](https://thegraph.com/)**: Decentralized indexing protocol for organizing blockchain data.
 -   **[Graph CLI](https://github.com/graphprotocol/graph-cli)**: Command-line interface for developing and deploying subgraphs.
 -   **[AssemblyScript](https://www.assemblyscript.org/)**: A TypeScript-like language compiled to WebAssembly, used for writing subgraph mapping logic.
--   **[Alchemy Subgraphs](https://www.alchemy.com/subgraphs)**: Hosted service for subgraph deployment and querying.
+-   **[Goldsky](https://goldsky.com/)**: Hosted service currently used for subgraph deployment and querying (see CLAUDE.md for endpoint details). Note: `appchain-contracts/` and `settlement-chain-contracts/` contain an earlier, unmaintained Alchemy-based prototype and are not the active deployment target.
 
 ## Repository Structure
 
@@ -62,10 +62,11 @@ npm install
 yarn install
 ```
 
-3.  **Configure Environment Variables:** Create a `.env` file in the relevant subgraph project (`settlement-chain-contracts` or `appchain-contracts`) and add your Alchemy deploy key and a version label:
+3.  **Configure Environment Variables:** Create a `.env` file in the relevant subgraph project (`app-chain` or `settlement-chain`) and add your Goldsky API key, project ID, and a version label:
 
 ```text
-DEPLOY_KEY=YOUR_ALCHEMY_DEPLOY_KEY
+GOLDSKY=YOUR_GOLDSKY_API_KEY
+PROJECT_ID=YOUR_GOLDSKY_PROJECT_ID
 VERSION_LABEL=v0.3.0
 ```
 
@@ -75,7 +76,7 @@ TODO
 
 ## Querying Data
 
-Once your subgraphs are deployed and synced, you can query their data using GraphQL. Alchemy provides a dedicated GraphQL API endpoint for each deployed subgraph. You can find this endpoint on your subgraph's dashboard in the Alchemy UI.
+Once your subgraphs are deployed and synced, you can query their data using GraphQL. Goldsky provides a stable, tagged GraphQL API endpoint for each deployed subgraph (see `CLAUDE.md` for the current endpoint URLs). Always use the `/stable/gn` tagged endpoint rather than a versioned one.
 
 ## License
 

--- a/appchain-contracts/README.md
+++ b/appchain-contracts/README.md
@@ -1,3 +1,5 @@
+> **Warning: Deprecated/unused prototype.** This project is not the active deployment target. See the root README for the active Goldsky-based subgraphs in `app-chain/` and `settlement-chain/`.
+
 # XMTP Appchain Subgraph
 
 This subgraph indexes events from the XMTP Payer Portal contracts deployed on XMTP Sepolia (appchain). It provides comprehensive data for message tracking, usage analytics, and bridge operations.

--- a/settlement-chain-contracts/README.md
+++ b/settlement-chain-contracts/README.md
@@ -1,3 +1,5 @@
+> **Warning: Deprecated/unused prototype.** This project is not the active deployment target. See the root README for the active Goldsky-based subgraphs in `app-chain/` and `settlement-chain/`.
+
 # XMTP Settlement Chain Subgraph
 
 This subgraph indexes events from the XMTP Payer Portal contracts deployed on Base Sepolia (settlement chain). It provides comprehensive data for balance tracking, transaction history, rate management, and bridge operations.


### PR DESCRIPTION
Fixes documentation inconsistency reported in #18.

README.md and GITFLOW.md described an Alchemy/Satsuma deployment target,
while the actually deployed and maintained subgraphs (app-chain/,
settlement-chain/) deploy to Goldsky per package.json scripts and CLAUDE.md.
The appchain-contracts/ and settlement-chain-contracts/ projects are an
earlier, unmaintained Alchemy-based prototype (last touched June 2025) and
are not the active deployment target.

Changes:
- README.md: replaced Alchemy references with Goldsky, updated env var
  example, added a note pointing out the unmaintained prototype folders
- GITFLOW.md: replaced Satsuma endpoint URLs with the real Goldsky
  stable-tagged endpoints from CLAUDE.md
- appchain-contracts/README.md, settlement-chain-contracts/README.md:
  added a deprecated/unused-prototype warning

## Scope / What this PR does NOT fix

This is a documentation-only change. It does not touch any deployment
manifests, package.json scripts, or the funding-portal frontend (which
is a separate, private repo we don't have access to).

The intermittent 404 reported in #18 is most likely caused by one of:
1. A stale or incorrect Goldsky endpoint/tag configured in
   funding-portal's environment variables (e.g. on Vercel).
2. The Goldsky subgraph itself losing its `stable` tag on a redeploy,
   or an indexing/network issue on Goldsky's side (the app-chain
   subgraph runs on a custom `xmtp-ropsten` network, which CLAUDE.md
   notes can require Goldsky support involvement if unavailable).
3. A cached/stale frontend build still pointing at an old endpoint.

None of these can be diagnosed or fixed from this repo alone. This PR
just makes sure the documentation here points at the real, current
Goldsky endpoints, so whoever investigates funding-portal has one
accurate source to check against instead of three conflicting ones.

**Suggested next step**: whoever owns `funding-portal` should confirm
its env vars match the endpoints in `CLAUDE.md`, and/or check the
Goldsky dashboard for `project_cmh3prjsr002wr4p22cdshlhh` to see if
either subgraph has an indexing issue or missing `stable` tag.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix documentation to replace Alchemy/Satsuma references with Goldsky
> - Updates [GITFLOW.md](https://github.com/xmtp/subgraphs/pull/19/files#diff-63f8c311dab8a34672bbc80fdd9a38fc599ffa8f1183a81dca5941f85f1b1d97) to replace all Alchemy/Satsuma endpoint URLs with Goldsky stable endpoints using the `/stable/gn` path, and notes that mainnet is not yet deployed.
> - Updates [README.md](https://github.com/xmtp/subgraphs/pull/19/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) to reflect Goldsky as the subgraph provider, with Goldsky-specific environment variables, and marks `appchain-contracts/` and `settlement-chain-contracts/` as deprecated prototypes.
> - Adds deprecation warnings to [appchain-contracts/README.md](https://github.com/xmtp/subgraphs/pull/19/files#diff-9f4df6e4c1418c1707cfbcdf941466113fa274c8c75ecb42bf015edeab83bcc4) and [settlement-chain-contracts/README.md](https://github.com/xmtp/subgraphs/pull/19/files#diff-5373a3fcf2896b9a23db53a988b98c1d5ec9981c9fa69c3e14c540294f2f3ad0) pointing to the active `app-chain/` and `settlement-chain/` subgraphs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5968d80.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->